### PR TITLE
Limit vim modeline salvage to header section.

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -267,7 +267,7 @@ sub read_and_parse_old_spec {
       next;
     }
 
-    if ( /^# vim:/ ) {
+    if ( /^# vim:/ && $current_section eq "header" ) {
       $vim_modeline = $_;
       next;
     }


### PR DESCRIPTION
There might be legitimate usages of vim modelines in the middle of
a spec file (e.g. in inline config file sections), so best not mess
with that all over the file. Case in point:

https://build.opensuse.org/package/view_file/Apache:Modules/apache2-mod_fastcgi/apache2-mod_fastcgi.spec?expand=1
