### PR TITLE
Allow removing Group tags from spec files

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -1,7 +1,7 @@
 #! /usr/bin/perl -w
 #
 # vim:sw=2:et
-# 
+#
 
 BEGIN {
   unshift @INC, ".";
@@ -52,7 +52,7 @@ my @global_tags_list = (
   'Name',
   'NoPatch',
   'NoSource',
-  'Obsoletes', 
+  'Obsoletes',
   'Patch\d*',
   'Prefix',
   'PreReq',
@@ -257,7 +257,7 @@ sub read_and_parse_old_spec {
 
     if ( /^\s*$/ && $current_section ne "description") {
       # stop preamble parsing on two blank lines
-      if ($print_comments eq "false" && 
+      if ($print_comments eq "false" &&
 	    $oldspec[0] && $oldspec[-1] eq "XXXBLANKLINE") {
 	$print_comments = "true";
 	push @oldspec, "XXXDOUBLELINE";

--- a/prepare_spec
+++ b/prepare_spec
@@ -717,7 +717,9 @@ while (@oldspec) {
     my $license = $seen_licenses{$current_package} || $main_license;
     printf("%-16s%s\n", "License:", $license) if $license && (!$license_unique || $first_summary || $current_package eq $base_package);
     my $group = $seen_groups{$current_package} || $main_group;
-    printf("%-16s%s\n", "Group:", $group) if (!$groups_unique || $first_summary || $current_package eq $base_package);
+    if ($group) {
+      printf("%-16s%s\n", "Group:", $group) if (!$groups_unique || $first_summary || $current_package eq $base_package);
+    }
     $first_summary = 0;
   } else {
     print "$line\n";


### PR DESCRIPTION
Format spec files always introduced an empty group tag if undefined. This is not desireable.
