### PR TITLE
Security fixes

### DIFF
--- a/format_spec_file
+++ b/format_spec_file
@@ -31,6 +31,11 @@ for i in $MYSPECFILES; do
     echo "WARNING: no spec file found"
     exit 0
   fi
+  if [ "$i" != "${i##*/}" ]; then
+    # no path separators, please ("security" issue)
+    echo "$i: illegal filename"
+    exit 1
+  fi
   if /usr/lib/obs/service/format_spec_file.files/prepare_spec "$i" > "$MYOUTDIR/$i.$$"; then
     # remove all file files which are indendical to committed files
     # be carefull for the case that $MYOUDIR is local dir

--- a/patch_license
+++ b/patch_license
@@ -243,7 +243,7 @@ sub read_and_parse_old_spec {
   $ifhandler->{"disabled"} = 0;
 
   my @readspec;
-  open ( SPEC , "$specfile" ) || die "can't read specfile";
+  open ( SPEC , '<', "$specfile" ) || die "can't read specfile";
   @readspec = <SPEC>;
   close SPEC;
   chomp @readspec;
@@ -551,7 +551,7 @@ if ( $specdir eq "" ) {
 }
 my $xdefinelist;
 my $seen_name = 0;
-open ( SPE , "$specfile" );
+open ( SPE , '<', "$specfile" );
 while ( <SPE> ) {
   chomp;
 

--- a/prepare_spec
+++ b/prepare_spec
@@ -247,7 +247,7 @@ sub read_and_parse_old_spec {
   $ifhandler->{"disabled"} = 0;
 
   my @readspec;
-  open ( SPEC , "$specfile" ) || die "can't read specfile";
+  open ( SPEC , '<', "$specfile" ) || die "can't read specfile";
   @readspec = <SPEC>;
   close SPEC;
   chomp @readspec;
@@ -576,7 +576,7 @@ if ( $specdir eq "" ) {
 
 my $xdefinelist;
 my $seen_name = 0;
-open ( SPE , "$specfile" );
+open ( SPE , '<', "$specfile" ) || die("open $specfile: $!\n");
 while ( <SPE> ) {
   chomp();
   if ( /^%define/ ) {


### PR DESCRIPTION
Don't allow --specfile arguments that contain path separators: otherwise it is possible to trash
"arbitrary" files (e.g. by using a number of /../ components).

Explicitly pass mode argument to open for user specified files: otherwise we could execute
"arbitrary" code using perl's ipc mechansim.