### PR TITLE
prepare_spec: Improve the license and group comments handling

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -713,6 +713,14 @@ while (@oldspec) {
   } elsif ($line eq "XXXRELEASE") {
     printf("%-16s%s\n", "Release:", "0") ;
   } elsif ($line =~ m/XXXPOSTSUMMARY (.*)$/) {
+    # There is a chance to have some comments that should appear before
+    # licenses and groups so print them here.
+    $line = shift @oldspec;
+    while ($line =~ m/^#.*/) {
+      print "$line\n";
+      $line = shift @oldspec;
+    }
+    unshift(@oldspec, $line);
     my $current_package = $1;
     my $license = $seen_licenses{$current_package} || $main_license;
     printf("%-16s%s\n", "License:", $license) if $license && (!$license_unique || $first_summary || $current_package eq $base_package);


### PR DESCRIPTION
Comments appearing between Summary and License/Group should not be
re-arranged since they usually refer to the tags below them. This
improves the situation by examining the lines following the Summary
tag and if it's a comment (or a sequense of comments) they are printed
before the License and Group tags.

Fixes: #13
Signed-off-by: Markos Chandras <mchandras@suse.de>