### PR TITLE
format_spec_file: Handle empty output directory

### DIFF
--- a/format_spec_file
+++ b/format_spec_file
@@ -26,6 +26,10 @@ RETURN=0
 if [ -z "$MYSPECFILES" ]; then
   MYSPECFILES=`echo *.spec`
 fi
+if [ -z "$MYOUTDIR" ]; then
+  MYOUTDIR=`pwd`
+fi
+
 for i in $MYSPECFILES; do
   if [ "$i" == '*.spec' ]; then
     echo "WARNING: no spec file found"


### PR DESCRIPTION
If we don't use the --outdir parameter then the output directory is set
to an empty string so the script is trying to create files in the root
directory because of all the $MYOUTDIR/$i code snippets resulting to
the following failures:

/usr/lib/obs/service/format_spec_file: line 39: /openvswitch.spec.20210:
Permission denied

We fix this by setting the current working directory as the default
output directory which is usually the directory containing our
spec files.

Signed-off-by: Markos Chandras <mchandras@suse.de>