### PR TITLE
format_spec_file: Fix usage message

### DIFF
--- a/format_spec_file
+++ b/format_spec_file
@@ -15,7 +15,7 @@ while test $# -gt 0; do
     ;;
     *)
       echo Unknown parameter $1.
-      echo 'Usage: this service is not accepting parameters'
+      echo 'Usage: this service only accepts the --outdir and --specfile parameters.'
       exit 1
     ;;
   esac


### PR DESCRIPTION
This script actually accepts the --outdir and --specfile parameters
so fix the usage message.

Signed-off-by: Markos Chandras mchandras@suse.de
