### PR TITLE
Add Qt-Company-Qt-exception-1.1 to the exceptions.

### DIFF
--- a/licences_exceptions.txt
+++ b/licences_exceptions.txt
@@ -23,3 +23,4 @@ i2p-gpl-java-exception
 mif-exception
 openvpn-openssl-exception
 u-boot-exception-2.0
+Qt-Company-Qt-exception-1.1


### PR DESCRIPTION
Fixes boo#967696 and allows packages with this exception to build (currently
they fail).

The exception has been approved by the legal team (see the bug report
for discussion).