### PR TITLE
License update (Qt-company exceptions)

### DIFF
--- a/licenses_changes.txt
+++ b/licenses_changes.txt
@@ -109,6 +109,7 @@ BSD-2-Clause-FreeBSD	BSD-2-Clause-FreeBSD
 BSD-2-Clause-FreeBSD+	BSD-2-Clause-FreeBSD+
 BSD-2-Clause-NetBSD	BSD-2-Clause-NetBSD
 BSD-2-Clause-NetBSD+	BSD-2-Clause-NetBSD+
+BSD-2-Clause-Patent	https://opensource.org/licenses/BSDplusPatent
 BSD-3-Clause	BSD (3-Clause)
 BSD-3-Clause	BSD 3-Clause
 BSD-3-Clause	BSD 3-clause (or similar)
@@ -400,6 +401,7 @@ GPL-3.0+	GPL v3 or later
 GPL-3.0+	GPL-3+
 GPL-3.0+	GPL-3.0+
 GPL-3.0+	GPLv3+
+GPL-3.0-with-Qt-Company-Qt-exception-1.1	GPL-3.0-with-Qt-Company-Qt-exception-1.1
 Giftware	Giftware
 Giftware+	Giftware+
 Glide	Glide
@@ -476,6 +478,7 @@ LGPL-2.1+	LGPL-2.0.1 or later
 LGPL-2.1+	LGPL-2.1+
 LGPL-2.1+	LGPLv2+
 LGPL-2.1+	LGPLv2.1+
+LGPL-2.1-with-Qt-Company-Qt-exception-1.1	LGPL-2.1-with-Qt-Company-Qt-exception-1.1
 LGPL-3.0	GNU Lesser General Public License (LGPL), Version 3
 LGPL-3.0	GNU Lesser General Public License version 3 (LGPL v3)
 LGPL-3.0	LGPL-3.0
@@ -483,6 +486,7 @@ LGPL-3.0	LGPLv3
 LGPL-3.0+	LGPL v3 or later
 LGPL-3.0+	LGPL-3.0+
 LGPL-3.0+	LGPLv3+
+LGPL-3.0-with-Qt-Company-Qt-exception-1.1	LGPL-3.0-with-Qt-Company-Qt-exception-1.1
 LGPLLR	LGPLLR
 LGPLLR+	LGPLLR+
 LPL-1.0	LPL-1.0


### PR DESCRIPTION
Diff was generated by calling sh fetch-licenses.sh

The exceptions are listed on license.opensuse.org