### PR TITLE
Use URL instead of Url

### DIFF
--- a/patch_license
+++ b/patch_license
@@ -82,6 +82,8 @@ sub capitalize_case($)
 {
   my ($tag) = @_;
 
+  return $tag if $tag =~ m/Url|URL/;
+
   $tag = lc($tag);
 
   $tag =~ s/docdir/DocDir/i;

--- a/prepare_spec
+++ b/prepare_spec
@@ -80,6 +80,8 @@ sub unify {
 sub capitalize_case($) {
   my ($tag) = @_;
 
+  return $tag if $tag =~ m/Url|URL/;
+
   $tag = lc($tag);
 
   $tag =~ s/docdir/DocDir/i;


### PR DESCRIPTION
There are currently two tools performing similar actions, spec-cleaner and
format_spec_file. And at this moment they fight over who is right how to
format URL.