### PR TITLE
Change URL in comment block to https://

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -689,7 +689,7 @@ $copy_list
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 EOF
 


### PR DESCRIPTION
Point people to https://bugs.opensuse.org instead of http://bugs.opensuse.org