### PR TITLE
Use copyright line without the . at the end

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -668,7 +668,7 @@ for my $tag (qw(BuildRequires Requires Provides Obsoletes)) {
 
 my $thisyear = localtime->year() + 1900;
 
-unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC.";
+unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC";
 
 my $copy_list = join("\n", @copyrights);
 


### PR DESCRIPTION
The '.' should be used to separate fields and we have just the company
name.
Also right now the spec-cleaner and the format_spec_file remove and
add the dot respectively and override each other.