### PR TITLE
Allow to override date

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -505,7 +505,7 @@ our $base_package = "";
     }
     print "$self->{vim_mode}\n" if $self->{vim_mode};
 
-    my $thisyear   = localtime->year() + 1900;
+    my $thisyear   = localtime($ENV{SOURCE_DATE_EPOCH}||time)->year() + 1900;
     my @copyrights = @{$self->{copyright} || []};
     unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC";
 


### PR DESCRIPTION
Allow to override date
to fix tests after 2021

Without this patch, tests failed later with

 --- testing/AppStream.spec.out 2021-01-28 10:06:07.000000000 +0000
 +++ testing/AppStream.spec.new 2036-04-14 02:13:09.177052883 +0000
 @@ -1,7 +1,7 @@
  #
  # spec file for package AppStream
  #
 -# Copyright (c) 2021 SUSE LLC
 +# Copyright (c) 2036 SUSE LLC