### PR TITLE
List SUSE-LicenseRef-KDE-Accepted-LGPL exception boo#1195978

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ zlib-acknowledgement | zlib/libpng License with Acknowledgement
 |SUSE-LGPL-2.1-with-digia-exception-1.1|
 |SUSE-LGPL-2.1-with-nokia-exception-1.1|
 |SUSE-Liberation|
+|SUSE-LicenseRef-KDE-Accepted-LGPL|
 |SUSE-MIT-Khronos|
 |SUSE-Manpages|
 |SUSE-Matplotlib|

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Aladdin | Aladdin Free Public License
 Apache-1.0 | Apache License 1.0
 Apache-1.1 | Apache License 1.1
 Apache-2.0 | Apache License 2.0
+App-s2p | App::s2p License
 Artistic-1.0-Perl | Artistic License 1.0 (Perl)
 Artistic-1.0-cl8 | Artistic License 1.0 w/clause 8
 Artistic-1.0 | Artistic License 1.0
@@ -154,6 +155,7 @@ Crossword | Crossword License
 CrystalStacker | CrystalStacker License
 Cube | Cube License
 D-FSL-1.0 | Deutsche Freie Software Lizenz
+DL-DE-BY-2.0 | Data licence Germany – attribution – version 2.0
 DOC | DOC License
 DRL-1.0 | Detection Rule License 1.0
 DSDP | DSDP License
@@ -169,6 +171,7 @@ EUDatagrid | EU DataGrid Software License
 EUPL-1.0 | European Union Public License 1.0
 EUPL-1.1 | European Union Public License 1.1
 EUPL-1.2 | European Union Public License 1.2
+Elastic-2.0 | Elastic License 2.0
 Entessa | Entessa Public License v1.0
 ErlPL-1.1 | Erlang Public License v1.1
 Eurosym | Eurosym License
@@ -230,6 +233,7 @@ Intel | Intel Open Source License
 Interbase-1.0 | Interbase Public License v1.0
 JPNIC | Japan Network Information Center License
 JSON | JSON License
+Jam | Jam License
 JasPer-2.0 | JasPer License
 LAL-1.2 | Licence Art Libre 1.2
 LAL-1.3 | Licence Art Libre 1.3
@@ -385,6 +389,7 @@ SSH-short | SSH short notice
 SSPL-1.0 | Server Side Public License, v 1
 SWL | Scheme Widget Library (SWL) Software License Agreement
 Saxpath | Saxpath License
+SchemeReport | Scheme Language Report License
 Sendmail-8.23 | Sendmail License 8.23
 Sendmail | Sendmail License
 SimPL-2.0 | Simple Public License 2.0
@@ -416,6 +421,7 @@ W3C | W3C Software Notice and License (2002-12-31)
 WTFPL | Do What The F*ck You Want To Public License
 Watcom-1.0 | Sybase Open Watcom Public License 1.0
 Wsuipa | Wsuipa License
+X11-distribute-modifications-variant | X11 License Distribution Modification Variant
 X11 | X11 License
 XFree86-1.1 | XFree86 License 1.1
 XSkat | XSkat License
@@ -432,7 +438,6 @@ Zimbra-1.3 | Zimbra Public License v1.3
 Zimbra-1.4 | Zimbra Public License v1.4
 Zlib | zlib License
 blessing | SQLite Blessing
-bzip2-1.0.5 | bzip2 and libbzip2 License v1.0.5
 bzip2-1.0.6 | bzip2 and libbzip2 License v1.0.6
 copyleft-next-0.3.0 | copyleft-next 0.3.0
 copyleft-next-0.3.1 | copyleft-next 0.3.1

--- a/licenses_changes.txt
+++ b/licenses_changes.txt
@@ -715,6 +715,7 @@ SUSE-LGPL-2.1-with-nokia-exception-1.1	Part of the license choice in libqt4
 SUSE-LGPL-2.1-with-nokia-exception-1.1+	SUSE-LGPL-2.1-with-nokia-exception-1.1+
 SUSE-Liberation	LiberationFontsLicense (Fedora calls this the Liberation license - it will be easier to get it upstream if we adopt that)
 SUSE-Liberation+	SUSE-Liberation+
+SUSE-LicenseRef-KDE-Accepted-LGPL LicenseRef-KDE-Accepted-LGPL
 SUSE-MIT-Khronos	https://github.com/KhronosGroup/KTX/blob/master/lib/loader.c
 SUSE-MIT-Khronos+	SUSE-MIT-Khronos+
 SUSE-Manpages	Manpages licenses (linux man pages e.g.)

--- a/licenses_changes.txt
+++ b/licenses_changes.txt
@@ -58,6 +58,7 @@ Apache-2.0	Apache-2.0
 Apache-2.0	The Apache Software License
 Apache-2.0+	ASLv2.0+
 Apache-2.0+	SUSE-Apache-2.0+
+App-s2p	App-s2p
 Artistic-1.0	Artistic
 Artistic-1.0	Artistic 1.0
 Artistic-1.0	Artistic License
@@ -219,6 +220,7 @@ Crossword	Crossword
 CrystalStacker	CrystalStacker
 Cube	Cube
 D-FSL-1.0	D-FSL-1.0
+DL-DE-BY-2.0	DL-DE-BY-2.0
 DOC	DOC
 DRL-1.0	DRL-1.0
 DSDP	DSDP
@@ -242,6 +244,7 @@ EUDatagrid	EUDatagrid
 EUPL-1.0	EUPL-1.0
 EUPL-1.1	EUPL-1.1
 EUPL-1.2	EUPL-1.2
+Elastic-2.0	Elastic-2.0
 Entessa	Entessa
 ErlPL-1.1	ErlPL-1.1
 ErlPL-1.1	Erlang Public License
@@ -380,6 +383,7 @@ Interbase-1.0	Interbase-1.0
 JPNIC	JPNIC
 JSON	JSON
 JSON	SUSE-JSON
+Jam	Jam
 JasPer-2.0	JasPer-2.0
 LAL-1.2	LAL-1.2
 LAL-1.2	https://spdx.org/licenses/LAL-1.2.html
@@ -783,6 +787,7 @@ SUSE-wxWidgets-3.1	https://www.wxwidgets.org/about/licence/
 SUSE-wxWidgets-3.1+	SUSE-wxWidgets-3.1+
 SWL	SWL
 Saxpath	Saxpath
+SchemeReport	SchemeReport
 Sendmail	SUSE-Sendmail
 Sendmail	Sendmail
 Sendmail-8.23	Sendmail-8.23
@@ -828,6 +833,7 @@ X11	X11
 X11	X11 (BSD like)
 X11	X11 MIT
 X11	X11/MIT
+X11-distribute-modifications-variant	X11-distribute-modifications-variant
 XFree86-1.1	XFree86-1.1
 XSkat	XSkat
 Xerox	Xerox
@@ -849,7 +855,6 @@ Zlib	Zlib License
 Zlib	zlib
 Zlib	zlib/libpng License
 blessing	blessing
-bzip2-1.0.5	bzip2-1.0.5
 bzip2-1.0.6	bzip2-1.0.6
 copyleft-next-0.3.0	copyleft-next-0.3.0
 copyleft-next-0.3.1	copyleft-next-0.3.1


### PR DESCRIPTION
List SUSE-LicenseRef-KDE-Accepted-LGPL exception boo#1195978

https://bugzilla.opensuse.org/show_bug.cgi?id=1195978
https://github.com/spdx/license-list-XML/issues/928

I could appreciate a review

Expectation is to get this one pass

[  139s] RPMLINT report:
[  139s] ===============
[  153s] libksane-devel.x86_64: W: no-dependency-on libksane*/libksane-libs/liblibksane*
[  153s] libKF5Sane5.x86_64: W: no-version-in-last-changelog
[  153s] libksane-devel.x86_64: W: no-version-in-last-changelog
[  153s] libksane-lang.noarch: W: no-version-in-last-changelog
[  153s] libksane.src: W: no-version-in-last-changelog
[  153s] The latest changelog entry doesn't contain a version. Please insert the
[  153s] version that is coherent with the version of the package and rebuild it.
[  153s] 
[  153s] libKF5Sane5.x86_64: E: invalid-license (Badness: 100000) LicenseRef-KDE-Accepted-LGPL
[  153s] libksane-devel.x86_64: E: invalid-license (Badness: 100000) LicenseRef-KDE-Accepted-LGPL
[  153s] libksane-lang.noarch: E: invalid-license (Badness: 100000) LicenseRef-KDE-Accepted-LGPL
[  153s] libksane.src: E: invalid-license (Badness: 100000) LicenseRef-KDE-Accepted-LGPL
[  153s] The specified license string is not recognized. Please refer to
[  153s] https://spdx.org/licenses/ for the list of known licenses and their exact
[  153s] spelling.
[  153s] 
[  153s] (none): E: badness 400000 exceeds threshold 1000, aborting.
[  153s] 4 packages and 0 specfiles checked; 4 errors, 5 warnings.