### PR TITLE
Change spelling case of Url tag

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -666,7 +666,7 @@ EOF
     $tag =~ s/pre/Pre/;
     $tag =~ s/confl/Confl/i;
     $tag =~ s/prov/Prov/i;
-    $tag =~ s/url/URL/i;
+    $tag =~ s/url/Url/i;
     $tag =~ s/^(\w)/uc($1)/e;
 
     return $tag;


### PR DESCRIPTION
The **Url** tag went from all letters being uppercase to only having the first letter capitalized. This change occurred years ago upstream.

Reference: [tags manual](https://github.com/rpm-software-management/rpm/blob/master/docs/manual/tags.md).
