### PR TITLE
Add Free-Art-1.2

### DIFF
--- a/licenses_changes.txt
+++ b/licenses_changes.txt
@@ -706,6 +706,7 @@ SUSE-FLTK	Fltk
 SUSE-FLTK+	SUSE-FLTK+
 SUSE-Firmware	Firmware license, redistributable unmodified
 SUSE-Firmware+	SUSE-Firmware+
+SUSE-Free-Art-1.2	http://www.worldlii.org/int/other/PubRL/2000/4.html
 SUSE-Free-Art-1.3	http://artlibre.org/licence/lal/en
 SUSE-Free-Art-1.3+	SUSE-Free-Art-1.3+
 SUSE-Freetype	Freetype


### PR DESCRIPTION
* http://www.worldlii.org/int/other/PubRL/2000/4.html
* Usage gcompris-qt-3.3/LICENSES/LicenseRef-Free-Art-Licence-1.2.processed.txt


We should update spec of https://build.opensuse.org/package/view_file/openSUSE:Factory/gcompris-qt/gcompris-qt.spec?expand=1 once it's accepted as we currently accept only SUSE-Free-Art-1.3