### PR TITLE
Avoid using temporary files for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ install:
 check:
 	set -e ;\
 	for i in testing/*.spec; do \
-	  COPYRIGHT_YEAR=2021 perl prepare_spec $$i > $$i.new ;\
-	  diff -u $$i.out $$i.new ;\
-	  rm $$i.new ;\
+	  COPYRIGHT_YEAR=2021 perl prepare_spec $$i | \
+	  diff -u --label $$i.out --label $$i.actual $$i.out - ;\
 	done ;\
 
 format:


### PR DESCRIPTION
Avoid using temporary files for tests.
This way there is no left-over when a test fails (via `set -e`)
and less churn on the disk.