### PR TITLE
Reduce default SUSE copyright claims

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -619,7 +619,7 @@ EOF
     my ($self, $line) = @_;
     my $copyright = $line;
     # we update old SUSE legal entities to the current one
-    $copyright =~ s{\s*(?:copyrights?) (?:\(c\) )?((?:2\d\d\d )?)suse (?:linux )?(?:products )?(?:gmbh|llc)?,?\s*(?:nuremberg|n..?rnberg)?,?(?:\s*germany\W+)?\s*}{ Copyright (c) $1SUSE LLC}i;
+    $copyright =~ s{\s*(?:copyrights?) (?:\(c\) )?((?:2\d\d\d )?)suse (?:linux )?(?:products )?(?:gmbh|llc)?,?\s*(?:nuremberg|n..?rnberg)?,?(?:\s*germany\W+)?\s*$}{ Copyright (c) $1SUSE LLC}i;
 
     if (length($copyright) <= 5) {    # not much left
       return;

--- a/prepare_spec
+++ b/prepare_spec
@@ -24,6 +24,7 @@ use File::Basename;
 our $debug        = 0;
 our $base_package = "";
 our $header_name;
+our $specfile;
 
 {
 
@@ -509,7 +510,20 @@ our $header_name;
     my $thisyear = $ENV{COPYRIGHT_YEAR};
     $thisyear ||= localtime($ENV{SOURCE_DATE_EPOCH} || time)->year() + 1900;
     my @copyrights = @{$self->{copyright} || []};
-    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC" if $ENV{ADD_SUSE_COPYRIGHT} and not grep /SUSE LLC/, @copyrights;
+    my $add_suse_copyright = $ENV{ADD_SUSE_COPYRIGHT};
+    $add_suse_copyright = 0 if grep /SUSE LLC/, @copyrights;
+    my $changesfile = $specfile;
+    $changesfile =~ s/\.spec$/.changes/;
+    if(!defined($add_suse_copyright) and open(my $fd, "<", $changesfile)) {
+      my $n=0;
+      while(<$fd>) {
+        if(/\w\@suse\.(?:com|cz|de)>/) {
+          $add_suse_copyright = 1;
+        }
+        last if $n++>0;
+      }
+    }
+    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC" if $add_suse_copyright;
 
     my $copy_list = join("\n", @copyrights);
 
@@ -1214,7 +1228,7 @@ if ($ARGV[0] eq '--debug') {
   shift @ARGV;
 }
 
-my $specfile = shift(@ARGV);
+$specfile = shift(@ARGV);
 if (!stat($specfile)) {
   die "$specfile is no file";
 }

--- a/prepare_spec
+++ b/prepare_spec
@@ -509,7 +509,7 @@ our $header_name;
     my $thisyear = $ENV{COPYRIGHT_YEAR};
     $thisyear ||= localtime($ENV{SOURCE_DATE_EPOCH} || time)->year() + 1900;
     my @copyrights = @{$self->{copyright} || []};
-    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC" unless(grep /SUSE LLC/, @copyrights);
+    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC" if $ENV{ADD_SUSE_COPYRIGHT} and not grep /SUSE LLC/, @copyrights;
 
     my $copy_list = join("\n", @copyrights);
 

--- a/prepare_spec
+++ b/prepare_spec
@@ -509,7 +509,7 @@ our $header_name;
     my $thisyear = $ENV{COPYRIGHT_YEAR};
     $thisyear ||= localtime($ENV{SOURCE_DATE_EPOCH} || time)->year() + 1900;
     my @copyrights = @{$self->{copyright} || []};
-    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC";
+    unshift @copyrights, "# Copyright (c) $thisyear SUSE LLC" unless(grep /SUSE LLC/, @copyrights);
 
     my $copy_list = join("\n", @copyrights);
 
@@ -618,11 +618,13 @@ EOF
   sub create_copyright_section {
     my ($self, $line) = @_;
     my $copyright = $line;
-    $copyright =~ s{\s*(\d+|copyrights?|\(c\)|suse|linux|products|gmbh|nuremberg|n..?rnberg|germany|\W+)\s*}{}gi;
+    # we update old SUSE legal entities to the current one
+    $copyright =~ s{\s*(?:copyrights?) (?:\(c\) )?((?:2\d\d\d )?)suse (?:linux )?(?:products )?(?:gmbh|llc)?,?\s*(?:nuremberg|n..?rnberg)?,?(?:\s*germany\W+)?\s*}{ Copyright (c) $1SUSE LLC}i;
+
     if (length($copyright) <= 5) {    # not much left
       return;
     }
-    $self->find("preamble")->add_copyright($line);
+    $self->find("preamble")->add_copyright($copyright);
   }
 
   sub add_to_current_section {

--- a/testing/aaa_base.spec.out
+++ b/testing/aaa_base.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package aaa_base
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/bazel-rules-android.spec
+++ b/testing/bazel-rules-android.spec
@@ -1,0 +1,61 @@
+#
+# spec file for package bazel-rules-android
+#
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+%define src_install_dir /usr/src/%{name}
+
+Name:           bazel-rules-android
+Version:        0.1.1
+Release:        0
+Summary:        Bazel rules for Android
+Group:          Development/Tools/Building
+License:        Apache-2.0
+Url:            https://github.com/bazelbuild/rules_android
+Source0:        https://github.com/bazelbuild/rules_android/archive/v%{version}.tar.gz#/rules_android-%{version}.tar.gz
+Source1:        %{name}-rpmlintrc
+BuildRequires:  fdupes
+BuildArch:      noarch
+
+%description
+Bazel rules to build software for Android.
+
+%package source
+Summary:        Source code of bazel-rules-android
+Group:          Development/Sources
+
+%description source
+Bazel rules to build software for Android.
+
+This package contains source code of bazel-rules-android.
+
+%prep
+%setup -q -n rules_android-%{version}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{src_install_dir}
+cp -R * %{buildroot}%{src_install_dir}
+fdupes %{buildroot}%{src_install_dir}
+
+%files source
+%license LICENSE
+%doc README.md
+%{src_install_dir}
+
+%changelog
+

--- a/testing/bazel-rules-android.spec.out
+++ b/testing/bazel-rules-android.spec.out
@@ -1,0 +1,61 @@
+#
+# spec file for package bazel-rules-android
+#
+# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%define src_install_dir /usr/src/%{name}
+
+Name:           bazel-rules-android
+Version:        0.1.1
+Release:        0
+Summary:        Bazel rules for Android
+Group:          Development/Tools/Building
+License:        Apache-2.0
+URL:            https://github.com/bazelbuild/rules_android
+Source0:        https://github.com/bazelbuild/rules_android/archive/v%{version}.tar.gz#/rules_android-%{version}.tar.gz
+Source1:        %{name}-rpmlintrc
+BuildRequires:  fdupes
+BuildArch:      noarch
+
+%description
+Bazel rules to build software for Android.
+
+%package source
+Summary:        Source code of bazel-rules-android
+Group:          Development/Sources
+
+%description source
+Bazel rules to build software for Android.
+
+This package contains source code of bazel-rules-android.
+
+%prep
+%setup -q -n rules_android-%{version}
+
+%build
+
+%install
+mkdir -p %{buildroot}%{src_install_dir}
+cp -R * %{buildroot}%{src_install_dir}
+fdupes %{buildroot}%{src_install_dir}
+
+%files source
+%license LICENSE
+%doc README.md
+%{src_install_dir}
+
+%changelog

--- a/testing/bazel-rules-android.spec.out
+++ b/testing/bazel-rules-android.spec.out
@@ -1,7 +1,6 @@
 #
 # spec file for package bazel-rules-android
 #
-# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2021 SUSE Software Solutions Germany GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/bazel-rules-android.spec.out
+++ b/testing/bazel-rules-android.spec.out
@@ -1,7 +1,8 @@
 #
 # spec file for package bazel-rules-android
 #
-# Copyright (c) 2021 SUSE LLCSoftware Solutions Germany GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/bazel-rules-android.spec.out
+++ b/testing/bazel-rules-android.spec.out
@@ -1,8 +1,7 @@
 #
 # spec file for package bazel-rules-android
 #
-# Copyright (c) 2021 SUSE LLC
-# Copyright (c) 2021 SUSE Software Solutions Germany GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLCSoftware Solutions Germany GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/bconds.changes
+++ b/testing/bconds.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Fri Feb  7 19:17:08 UTC 2025 - Bernhard Wiedemann <bwiedemann@suse.com>
+
+- dummy changelog to trigger automatic adding of Copyright line

--- a/testing/bconds.spec.out
+++ b/testing/bconds.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package bconds
 #
-
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/bconds.spec.out
+++ b/testing/bconds.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package bconds
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/boolean.spec.out
+++ b/testing/boolean.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package boolean
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/bracketdeps.spec.out
+++ b/testing/bracketdeps.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package bracketdeps
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/buildignore.spec.out
+++ b/testing/buildignore.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package buildignore
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/check.spec.out
+++ b/testing/check.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package check
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/cleansection.spec.out
+++ b/testing/cleansection.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package cleansection
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/cleansectionbig.spec.out
+++ b/testing/cleansectionbig.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package cleansectionbig
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/clustershell-broken.spec.out
+++ b/testing/clustershell-broken.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package clustershell-broken
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 # Copyright (c) 2017 Stephane Thiell <sthiell@stanford.edu>
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/clustershell.spec.out
+++ b/testing/clustershell.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package clustershell
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2017 SUSE LLC
 # Copyright (c) 2017 Stephane Thiell <sthiell@stanford.edu>
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/codeblock.spec.out
+++ b/testing/codeblock.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package codeblock
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/conditionalpkgs.spec.out
+++ b/testing/conditionalpkgs.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package conditionalpkgs
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/conditiondefreq.spec.out
+++ b/testing/conditiondefreq.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package conditiondefreq
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/conditionmultiline.spec.out
+++ b/testing/conditionmultiline.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package conditionmultiline
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/conditions.spec.out
+++ b/testing/conditions.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package conditions
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/configuremultiline.spec.out
+++ b/testing/configuremultiline.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package configuremultiline
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/conflicts.spec.out
+++ b/testing/conflicts.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package conflicts
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/cross-aarch64-gcc7.spec
+++ b/testing/cross-aarch64-gcc7.spec
@@ -1,0 +1,928 @@
+#
+# spec file
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%define pkgname cross-aarch64-gcc7
+%define cross_arch aarch64
+%define gcc_target_arch aarch64-suse-linux
+%define gcc_icecream 1
+#
+# spec file for package gcc (Version 4.0.1)
+#
+# Copyright (c) 2005 SUSE Linux AG, Nuernberg, Germany.
+# This file and all modifications and additions to the pristine
+# package are under the same license as the package itself.
+#
+# Please submit bugfixes or comments via http://www.suse.de/feedback/
+#
+
+# nospeccleaner
+
+%define build_cp 0%{!?gcc_accel:1}
+%define build_ada 0
+%define build_libjava 0
+%define build_java 0
+
+%define build_fortran 0%{?gcc_accel:1}
+%define build_objc 0
+%define build_objcp 0
+%define build_go 0
+%define build_hsa 0
+%define build_nvptx 0
+
+%define enable_plugins 0
+
+%define binutils_target %{cross_arch}
+%if "%{cross_arch}" == "armv7l" || "%{cross_arch}" == "armv7hl"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "armv6l" || "%{cross_arch}" == "armv6hl"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "armv5tel"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "arm-none"
+%define binutils_target arm
+%define build_cp 0
+%endif
+%if "%{cross_arch}" == "sparcv9"
+%define binutils_target sparc
+%endif
+%define canonical_target %(echo %{binutils_target} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%if "%{binutils_target}" == "avr" || "%{binutils_target}" == "spu"
+%define binutils_os %{canonical_target}
+%else
+%if "%{binutils_target}" == "epiphany" || "%{binutils_target}" == "nds32le" || "%{binutils_target}" == "rl78" || "%{binutils_target}" == "rx"
+%define binutils_os %{canonical_target}-elf
+%else
+%if "%{binutils_target}" == "arm"
+%define binutils_os %{canonical_target}-suse-linux-gnueabi
+%else
+%if 0%{?gcc_accel:1}
+%define binutils_os %{gcc_target_arch}
+%else
+%define binutils_os %{canonical_target}-suse-linux
+%endif
+%endif
+%endif
+%endif
+
+%if 0%{?gcc_icecream:1}
+%define sysroot %{_prefix}/%{gcc_target_arch}
+%else
+# offloading builds newlib in-tree and can install in
+# the GCC private path without extra sysroot
+%if 0%{!?gcc_accel:1}
+# use same sysroot as in binutils.spec
+%define sysroot %{_prefix}/%{binutils_os}/sys-root
+%endif
+%endif
+
+%if %{suse_version} >= 1220
+%define selfconflict() %1
+%else
+%define selfconflict() otherproviders(%1)
+%endif
+
+Name:           %{pkgname}
+%define biarch_targets x86_64 s390x powerpc64 powerpc sparc sparc64
+
+URL:            https://gcc.gnu.org/
+Version:        7.5.0+r278197
+Release:        0
+%define gcc_dir_version %(echo %version | sed 's/+.*//' | cut -d '.' -f 1)
+%define gcc_snapshot_revision %(echo %version | sed 's/[3-9]\.[0-9]\.[0-6]//' | sed 's/+/-/')
+%define binsuffix -7
+Group:          Development/Languages/C and C++
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Source:         gcc-%{version}.tar.xz
+Source1:        change_spec
+Source3:        gcc7-rpmlintrc
+Source4:        README.First-for.SuSE.packagers
+Source5:        nvptx-newlib.tar.xz
+Patch2:         gcc-add-defaultsspec.diff
+Patch5:         tls-no-direct.diff
+Patch6:         gcc43-no-unwind-tables.diff
+Patch7:         gcc48-libstdc++-api-reference.patch
+Patch9:         gcc48-remove-mpfr-2.4.0-requirement.patch
+Patch10:        gcc5-no-return-gcc43-workaround.patch
+Patch11:        gcc7-remove-Wexpansion-to-defined-from-Wextra.patch
+Patch12:        gcc7-stack-probe.diff
+Patch14:        gcc7-pr82248.diff
+Patch15:        gcc7-avoid-fixinc-error.diff
+Patch17:        gcc7-flive-patching.patch
+Patch18:        gcc7-bsc1146475.patch
+Patch19:        gcc7-pr85887.patch
+Patch20:        gcc7-bsc1160086.patch
+Patch21:        gcc7-pr92154.patch
+Patch22:        gcc7-pr93246.patch
+Patch23:        gcc7-pr92692.patch
+Patch24:        gcc48-bsc1161913.patch
+Patch25:        gcc7-pr93965.patch
+Patch26:        gcc7-pr93888.patch
+Patch27:        gcc7-pr94148.patch
+Patch29:        gcc7-pr97535.patch
+Patch30:        gcc7-pr88522.patch
+Patch31:        gcc7-testsuite-fixes.patch
+Patch32:        gcc7-pr81942.patch
+Patch33:        gcc7-sanitizer-cyclades.patch
+Patch34:        gcc7-ada-MINSTKSZ.patch
+Patch35:        gcc7-pr55917.patch
+Patch36:        gcc7-ada-Target_Name.patch
+Patch37:        gcc7-pr78263.patch
+Patch38:        gcc7-libsanitizer-cherry-pick-9cf13067cb5088626ba7-from-u.patch
+Patch39:        gcc7-libgo-don-t-include-linux-fs.h-when-building-gen-sys.patch
+Patch40:        gcc7-pr72764.patch
+Patch41:        gcc7-pr89124.patch
+Patch42:        libgcc-riscv-div.patch
+Patch43:        gcc7-aarch64-bsc1214052.patch
+Patch44:        gcc7-aarch64-untyped_call.patch
+Patch45:        gcc7-lra-elim.patch
+Patch46:        gcc7-bsc1216488.patch
+Patch47:        gcc7-pr87723.patch
+# A set of patches from the RH srpm
+Patch51:        gcc41-ppc32-retaddr.patch
+# Some patches taken from Debian
+Patch60:        gcc44-textdomain.patch
+Patch61:        gcc44-rename-info-files.patch
+# Feature backports
+Patch100:       gcc7-aarch64-moutline-atomics.patch
+Patch101:       gcc7-fix-retrieval-of-testnames.patch
+Patch102:       gcc7-aarch64-sls-miti-1.patch
+Patch103:       gcc7-aarch64-sls-miti-2.patch
+Patch104:       gcc7-aarch64-sls-miti-3.patch
+Patch105:       gcc7-pfe-0001-Backport-Add-entry-for-patchable_function_entry.patch
+Patch106:       gcc7-pfe-0002-Backport-Skip-fpatchable-function-entry-tests-for-nv.patch
+Patch107:       gcc7-pfe-0003-Backport-Error-out-on-nvptx-for-fpatchable-function-.patch
+Patch108:       gcc7-pfe-0004-Backport-Adapt-scan-assembler-times-for-alpha.patch
+Patch109:       gcc7-pfe-0005-Backport-patchable_function_entry-decl.c-Use-3-NOPs-.patch
+Patch110:       gcc7-pfe-0006-Backport-IBM-Z-Use-the-dedicated-NOP-instructions-fo.patch
+Patch111:       gcc7-pfe-0007-Backport-Add-regex-to-search-for-uppercase-NOP-instr.patch
+Patch112:       gcc7-pfe-0008-Backport-ICE-segmentation-fault-with-patchable_funct.patch
+Patch113:       gcc7-pfe-0009-Backport-patchable_function_entry-decl.c-Pass-mcpu-g.patch
+Patch114:       gcc7-pfe-0010-Backport-patchable_function_entry-decl.c-Do-not-run-.patch
+Patch115:       gcc7-pfe-0011-Backport-patchable_function_entry-decl.c-Add-fno-pie.patch
+Patch116:       gcc7-pfe-0012-Backport-PR-c-89946-ICE-in-assemble_start_function-a.patch
+Patch117:       gcc7-pfe-0013-Backport-targhooks.c-default_print_patchable_functio.patch
+Patch118:       gcc7-pfe-0014-Backport-Align-__patchable_function_entries-to-POINT.patch
+Patch119:       gcc7-pfe-0015-Backport-Fix-PR-93242-patchable-function-entry-broke.patch
+Patch120:       gcc7-pfe-0016-Backport-Fix-patchable-function-entry-on-arc.patch
+Patch121:       gcc7-pfe-0017-Backport-Add-patch_area_size-and-patch_area_entry-to.patch
+Patch122:       gcc7-pfe-0018-Backport-testsuite-Adjust-patchable_function-tests-f.patch
+Patch123:       gcc7-pfe-0019-Backport-Use-the-section-flag-o-for-__patchable_func.patch
+Patch124:       gcc7-pfe-0020-Backport-varasm-Fix-up-__patchable_function_entries-.patch
+Patch125:       gcc7-pfe-0021-Backport-rs6000-Avoid-fpatchable-function-entry-regr.patch
+Patch126:       gcc7-pfe-0022-Fix-unwinding-issues-when-pfe-is-enabled.patch
+Patch127:       gcc7-pr88345-min-func-alignment.diff
+
+# Define the canonical target and host architecture
+#   %%gcc_target_arch  is supposed to be the full target triple
+#   %%cross_arch       is supposed to be the rpm target variant arch
+#   %%TARGET_ARCH      will be the canonicalized target CPU part
+#   %%HOST_ARCH        will be the canonicalized host CPU part
+%if 0%{?gcc_target_arch:1}
+%define TARGET_ARCH %(echo %{cross_arch} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%else
+%define TARGET_ARCH %(echo %{_target_cpu} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%endif
+%if 0%{?disable_32bit:1}
+%define biarch 0
+%else
+%define biarch %(case " %{biarch_targets} " in (*" %{TARGET_ARCH} "*) echo 1;; (*) echo 0;; esac)
+%endif
+
+%define HOST_ARCH %(echo %{_target_cpu} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%ifarch ppc
+%define GCCDIST powerpc64-suse-linux
+%else
+%ifarch %sparc
+%define GCCDIST sparc64-suse-linux
+%else
+%ifarch %arm
+%define GCCDIST %{HOST_ARCH}-suse-linux-gnueabi
+%else
+%define GCCDIST %{HOST_ARCH}-suse-linux
+%endif
+%endif
+%endif
+
+%define libsubdir %{_libdir}/gcc/%{GCCDIST}/%{gcc_dir_version}
+%define gxxinclude %{_prefix}/include/c++/%{gcc_dir_version}
+
+%if "%{cross_arch}" != "nvptx"
+BuildRequires:  cross-%{binutils_target}-binutils
+Requires:       cross-%{binutils_target}-binutils
+%endif
+BuildRequires:  bison
+BuildRequires:  flex
+BuildRequires:  gcc-c++
+BuildRequires:  gettext-devel
+BuildRequires:  glibc-devel-32bit
+BuildRequires:  mpc-devel
+BuildRequires:  mpfr-devel
+BuildRequires:  perl
+%if %{suse_version} > 1220
+BuildRequires:  makeinfo
+%else
+BuildRequires:  texinfo
+%endif
+BuildRequires:  zlib-devel
+%ifarch %ix86 x86_64 ppc ppc64 s390 s390x ia64 %sparc hppa %arm
+BuildRequires:  isl-devel
+%endif
+%ifarch ia64
+BuildRequires:  libunwind-devel
+%endif
+%if 0%{!?gcc_icecream:1}
+%if 0%{?gcc_target_newlib:1} && 0%{!?gcc_libc_bootstrap:1}
+BuildRequires:  cross-%cross_arch-newlib-devel
+%endif
+%if 0%{!?gcc_libc_bootstrap:1} && "%{cross_arch}" == "avr"
+BuildRequires:  avr-libc
+%endif
+%if 0%{?gcc_target_glibc:1}
+BuildRequires:  cross-%cross_arch-glibc-devel
+%endif
+%if "%{cross_arch}" == "nvptx"
+BuildRequires:  nvptx-tools
+Requires:       cross-nvptx-newlib-devel >= %{version}-%{release}
+Requires:       nvptx-tools
+ExclusiveArch:  x86_64
+%define nvptx_newlib 1
+%endif
+%endif
+%if 0%{?gcc_icecream:1}
+ExclusiveArch:  ppc64le ppc64 x86_64 s390x
+%endif
+%define _binary_payload w.ufdio
+# Obsolete cross-ppc-gcc49 from cross-ppc64-gcc49 which has
+# file conflicts with it and is no longer packaged
+%if "%pkgname" == "cross-ppc64-gcc49"
+Obsoletes:      cross-ppc-gcc49 <= 4.9.0+r209354
+%endif
+%if 0%{?gcc_target_newlib:1}
+# Generally only one cross for the same target triplet can be installed
+# at the same time as we are populating a non-version-specific sysroot
+Provides:       %{gcc_target_arch}-gcc
+Conflicts:      %selfconflict %{gcc_target_arch}-gcc
+%endif
+%if 0%{?gcc_libc_bootstrap:1}
+# The -bootstrap packages file-conflict with the non-bootstrap variants.
+# Even if we don't actually (want to) distribute the bootstrap variants
+# the following avoids repo-checker spamming us endlessly.
+Conflicts:      cross-%{cross_arch}-gcc7
+%endif
+#!BuildIgnore: gcc-PIE
+BuildRequires:  update-alternatives
+Requires(post): update-alternatives
+Requires(preun):update-alternatives
+Summary:        The GNU Compiler Collection targeting %{cross_arch}
+License:        GPL-3.0-or-later
+
+%description
+The GNU Compiler Collection as a cross-compiler targeting %{cross_arch}.
+%if 0%{?gcc_icecream:1}
+Note this is only useful for building freestanding things like the
+kernel since it fails to include target libraries and headers.
+%endif
+%if 0%{?gcc_libc_bootstrap:1}
+This is a package that is necessary for bootstrapping another package
+only, it is not intended for any other use.
+%endif
+
+%prep
+%if 0%{?nvptx_newlib:1}
+%setup -q -n gcc-%{version} -a 5
+ln -s nvptx-newlib/newlib .
+%else
+%setup -q -n gcc-%{version}
+%endif
+
+#test patching start
+
+%patch -P 2
+%patch -P 5
+%patch -P 6
+%patch -P 7
+%if %{suse_version} < 1310
+%patch -P 9
+%endif
+%patch -P 10
+%patch -P 11
+%patch -P 12
+%patch -P 14
+%patch -P 15
+%patch -P 17 -p1
+%patch -P 18
+%patch -P 19
+%patch -P 20
+%patch -P 21 -p1
+%patch -P 22 -p1
+%patch -P 24 -p1
+%patch -P 25 -p1
+%patch -P 26 -p1
+%patch -P 27 -p1
+%patch -P 29
+%patch -P 30 -p1
+%patch -P 31 -p1
+%patch -P 32 -p1
+%patch -P 33 -p1
+%patch -P 34 -p1
+%patch -P 35 -p1
+%patch -P 36 -p1
+%patch -P 37 -p1
+%patch -P 38 -p1
+%patch -P 39 -p1
+%patch -P 40 -p1
+%patch -P 41 -p1
+%patch -P 42 -p1
+%patch -P 43 -p1
+%patch -P 44 -p1
+%patch -P 45 -p1
+%patch -P 46 -p1
+%patch -P 47 -p1
+%patch -P 51
+%patch -P 60
+%patch -P 61
+%patch -P 100 -p1
+%patch -P 23 -p1
+%patch -P 101 -p1
+%patch -P 102 -p1
+%patch -P 103 -p1
+%patch -P 104 -p1
+%patch -P 105 -p1
+%patch -P 106 -p1
+%patch -P 107 -p1
+%patch -P 108 -p1
+%patch -P 109 -p1
+%patch -P 110 -p1
+%patch -P 111 -p1
+%patch -P 112 -p1
+%patch -P 113 -p1
+%patch -P 114 -p1
+%patch -P 115 -p1
+%patch -P 116 -p1
+%patch -P 117 -p1
+%patch -P 118 -p1
+%patch -P 119 -p1
+%patch -P 120 -p1
+%patch -P 121 -p1
+%patch -P 122 -p1
+%patch -P 123 -p1
+%patch -P 124 -p1
+%patch -P 125 -p1
+%patch -P 126 -p1
+%patch -P 127 -p1
+
+#test patching end
+
+%build
+%define _lto_cflags %{nil}
+# Avoid rebuilding of generated files
+contrib/gcc_update --touch
+
+# SLE11 does not allow empty rpms
+%if %{suse_version} < 1310
+echo "This is a dummy package to provide a dependency." > README
+%endif
+
+rm -rf obj-%{GCCDIST}
+mkdir obj-%{GCCDIST}
+cd obj-%{GCCDIST}
+RPM_OPT_FLAGS="$RPM_OPT_FLAGS -U_FORTIFY_SOURCE"
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-fno-rtti//g' -e 's/-fno-exceptions//g' -e 's/-Wmissing-format-attribute//g' -e 's/-fstack-protector[^ ]*//g' -e 's/-ffortify=.//g' -e 's/-Wall//g' -e 's/-m32//g' -e 's/-m64//g'`
+%ifarch %ix86
+# -mcpu is superceded by -mtune but -mtune is not supported by
+# our bootstrap compiler.  -mcpu gives a warning that stops
+# the build process, so remove it for now.  Also remove all other
+# -march and -mtune flags.  They are superseeded by proper
+# default compiler settings now.
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-mcpu=i.86//g' -e 's/-march=i.86//g' -e 's/-mtune=i.86//g'`
+%endif
+%ifarch s390 s390x
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-fsigned-char//g'`
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-O1/-O2/g'`
+%endif
+%ifarch aarch64
+%if %{build_ada}
+# -mbranch-protection=standard flag is unsupported in gcc7 and we use GCC7 to build GCC7
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-mbranch-protection=standard//g'`
+%endif
+%endif
+%if 0%{?gcc_target_arch:1}
+# Kill all -march/tune/cpu because that screws building the target libs
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-m\(arch\|tune\|cpu\)=[^ ]*//g'`
+%endif
+# Replace 2 spaces by one finally
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/  / /g'`
+
+languages=c
+%if %{build_cp}
+languages=$languages,c++
+%endif
+%if %{build_objc}
+languages=$languages,objc
+%endif
+%if %{build_fortran}
+languages=$languages,fortran
+%endif
+%if %{build_objcp}
+languages=$languages,obj-c++
+%endif
+%if %{build_ada}
+languages=$languages,ada
+%endif
+%if %{build_go}
+languages=$languages,go
+%endif
+
+# In general we want to ship release checking enabled compilers
+# which is the default for released compilers
+#ENABLE_CHECKING="--enable-checking=yes"
+ENABLE_CHECKING="--enable-checking=release"
+#ENABLE_CHECKING=""
+
+# Work around tail/head -1 changes
+export _POSIX2_VERSION=199209
+
+%if %{build_ada}
+# Using the host gnatmake like
+#   CC="gcc%%{hostsuffix}" GNATBIND="gnatbind%%{hostsuffix}"
+#   GNATMAKE="gnatmake%%{hostsuffix}"
+# doesn't work due to PR33857, so an un-suffixed gnatmake has to be
+# available
+mkdir -p host-tools/bin
+cp -a /usr/bin/gnatmake%{hostsuffix} host-tools/bin/gnatmake
+cp -a /usr/bin/gnatlink%{hostsuffix} host-tools/bin/gnatlink
+cp -a /usr/bin/gnatbind%{hostsuffix} host-tools/bin/gnatbind
+cp -a /usr/bin/gcc%{hostsuffix} host-tools/bin/gcc
+cp -a /usr/bin/g++%{hostsuffix} host-tools/bin/g++
+ln -sf /usr/%{_lib} host-tools/%{_lib}
+export PATH="`pwd`/host-tools/bin:$PATH"
+%endif
+CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS" XCFLAGS="$RPM_OPT_FLAGS" \
+TCFLAGS="$RPM_OPT_FLAGS" \
+../configure \
+	--prefix=%{_prefix} \
+	--infodir=%{_infodir} \
+	--mandir=%{_mandir} \
+	--libdir=%{_libdir} \
+	--libexecdir=%{_libdir} \
+	--enable-languages=$languages \
+%if %{build_hsa} || %{build_nvptx}
+	--enable-offload-targets=\
+%if %{build_hsa}
+hsa,\
+%endif
+%if %{build_nvptx}
+nvptx-none, \
+%endif
+%endif
+%if %{build_nvptx}
+	--without-cuda-driver \
+%endif
+	$ENABLE_CHECKING \
+	--disable-werror \
+	--with-gxx-include-dir=%{_prefix}/include/c++/%{gcc_dir_version} \
+	--enable-ssp \
+	--disable-libssp \
+%if 0%{!?build_libvtv:1}
+	--disable-libvtv \
+%endif
+%ifnarch %mpx_arch
+	--disable-libmpx \
+%endif
+	--disable-libcc1 \
+%if %{enable_plugins}
+	--enable-plugin \
+%else
+	--disable-plugin \
+%endif
+	--with-bugurl="https://bugs.opensuse.org/" \
+	--with-pkgversion="SUSE Linux" \
+	--with-slibdir=/%{_lib} \
+	--with-system-zlib \
+	--enable-libstdcxx-allocator=new \
+	--disable-libstdcxx-pch \
+%if 0%{suse_version} <= 1320
+	--with-default-libstdcxx-abi=gcc4-compatible \
+%endif
+	--enable-version-specific-runtime-libs \
+	--with-gcc-major-version-only \
+	--enable-linker-build-id \
+	--enable-linux-futex \
+%if %{suse_version} >= 1315
+%ifarch %ix86 x86_64 ppc ppc64 ppc64le %arm aarch64 s390 s390x %sparc
+	--enable-gnu-indirect-function \
+%endif
+%endif
+	--program-suffix=%{binsuffix} \
+%if 0%{?disable_32bit:1}
+	--disable-multilib \
+%endif
+%if 0%{!?gcc_target_arch:1}
+%ifarch ia64
+	--with-system-libunwind \
+%else
+	--without-system-libunwind \
+%endif
+%endif
+%if 0%{?gcc_target_arch:1}
+	--program-prefix=%{gcc_target_arch}- \
+	--target=%{gcc_target_arch} \
+	--disable-nls \
+%if 0%{?sysroot:1}
+	--with-sysroot=%sysroot \
+%endif
+%if 0%{?build_sysroot:1}
+	--with-build-sysroot=%{build_sysroot} \
+%else
+%if 0%{?sysroot:1}
+	--with-build-sysroot=%{sysroot} \
+%endif
+%endif
+%if 0%{?binutils_os:1}
+	--with-build-time-tools=/usr/%{binutils_os}/bin \
+%endif
+%if 0%{?gcc_target_newlib}
+	--with-newlib \
+%if 0%{?gcc_libc_bootstrap:1}
+	--without-headers \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "spu"
+	--with-gxx-include-dir=%sysroot/include/c++/%{gcc_dir_version} \
+	--with-newlib \
+%endif
+%if "%{TARGET_ARCH}" == "nvptx"
+	--enable-as-accelerator-for=%{GCCDIST} \
+	--disable-sjlj-exceptions \
+	--enable-newlib-io-long-long \
+%endif
+%if "%{TARGET_ARCH}" == "avr"
+	--enable-lto \
+	--without-gxx-include-dir \
+	--with-native-system-header-dir=/include \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "arm"
+        --with-arch=armv6zk \
+        --with-tune=arm1176jzf-s \
+	--with-float=hard \
+	--with-abi=aapcs-linux \
+	--with-fpu=vfp \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv5tel"
+	--with-arch=armv5te \
+	--with-float=soft \
+	--with-mode=arm \
+	--with-abi=aapcs-linux \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv6hl"
+        --with-arch=armv6zk \
+        --with-tune=arm1176jzf-s \
+        --with-float=hard \
+        --with-abi=aapcs-linux \
+        --with-fpu=vfp \
+        --disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv7hl"
+	--with-arch=armv7-a \
+	--with-tune=cortex-a15 \
+	--with-float=hard \
+	--with-abi=aapcs-linux \
+	--with-fpu=vfpv3-d16 \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "aarch64"
+	--enable-fix-cortex-a53-835769 \
+	--enable-fix-cortex-a53-843419 \
+%endif
+%if "%{TARGET_ARCH}" == "powerpc" || "%{TARGET_ARCH}" == "powerpc64" || "%{TARGET_ARCH}" == "powerpc64le"
+%if "%{TARGET_ARCH}" == "powerpc"
+        --with-cpu=default32 \
+%endif
+%if "%{TARGET_ARCH}" == "powerpc64le"
+%if %{suse_version} >= 1350
+	--with-cpu=power8 \
+	--with-tune=power9 \
+%else
+%if %{suse_version} >= 1315 && %{suse_version} != 1320
+	--with-cpu=power8 \
+	--with-tune=power8 \
+%else
+	--with-cpu=power7 \
+	--with-tune=power7 \
+%endif
+%endif
+%else
+	--with-cpu-64=power4 \
+%endif
+	--enable-secureplt \
+	--with-long-double-128 \
+%if "%{TARGET_ARCH}" == "powerpc64le"
+	--enable-targets=powerpcle-linux \
+	--disable-multilib \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "sparc64"
+	--with-cpu=ultrasparc \
+	--with-long-double-128 \
+%endif
+%if "%{TARGET_ARCH}" == "sparc"
+	--with-cpu=v8 \
+	--with-long-double-128 \
+%endif
+%if "%{TARGET_ARCH}" == "i586"
+%if 0%{?sle_version:%sle_version} >= 150000
+	--with-arch-32=x86-64 \
+%else
+	--with-arch-32=i586 \
+%endif
+	--with-tune=generic \
+%endif
+%if "%{TARGET_ARCH}" == "x86_64"
+	--enable-multilib \
+	--with-arch-32=x86-64 \
+	--with-tune=generic \
+%endif
+%if "%{TARGET_ARCH}" == "s390"
+%if %{suse_version} >= 1310
+        --with-tune=zEC12 --with-arch=z196 \
+%else
+	--with-tune=z9-109 --with-arch=z900 \
+%endif
+	--with-long-double-128 \
+	--enable-decimal-float \
+%endif
+%if "%{TARGET_ARCH}" == "s390x"
+%if %{suse_version} >= 1310
+        --with-tune=zEC12 --with-arch=z196 \
+%else
+	--with-tune=z9-109 --with-arch=z900 \
+%endif
+	--with-long-double-128 \
+	--enable-decimal-float \
+%endif
+%if "%{TARGET_ARCH}" == "m68k"
+	--disable-multilib \
+%endif
+%if "%{TARGET_ARCH}" == "riscv64"
+	--disable-multilib \
+%endif
+	--build=%{GCCDIST} \
+	--host=%{GCCDIST}
+
+%if 0%{!?gcc_icecream:1} && 0%{!?gcc_libc_bootstrap:1}
+make %{?_smp_mflags}
+%else
+make %{?_smp_mflags} all-host
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+%package -n cross-%cross_arch-gcc7-icecream-backend
+Summary:        Icecream backend for the GNU C Compiler
+Group:          Development/Languages/C and C++
+
+%description -n cross-%cross_arch-gcc7-icecream-backend
+This package contains the icecream environment for the GNU C Compiler
+%endif
+
+%if 0%{?nvptx_newlib:1}
+%package -n cross-nvptx-newlib7-devel
+Summary:        newlib for the nvptx offload target
+Group:          Development/Languages/C and C++
+Provides:       cross-nvptx-newlib-devel = %{version}-%{release}
+Conflicts:      cross-nvptx-newlib-devel
+
+%description -n cross-nvptx-newlib7-devel
+Newlib development files for the nvptx offload target compiler.
+%endif
+
+%define targetlibsubdir %{_libdir}/gcc/%{gcc_target_arch}/%{gcc_dir_version}
+
+%install
+cd obj-%{GCCDIST}
+
+# install and fixup host parts
+make DESTDIR=$RPM_BUILD_ROOT install-host
+rm -rf $RPM_BUILD_ROOT/%{targetlibsubdir}/install-tools
+rm -f $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.la
+# common fixup
+rm -f $RPM_BUILD_ROOT%{_libdir}/libiberty.a
+
+# install and fixup target parts
+# debugedit is not prepared for this and crashes
+%if 0%{?gcc_icecream:1}
+# so expect the sysroot to be populated from natively built binaries
+%else
+%if 0%{!?gcc_libc_bootstrap:1}
+export NO_BRP_STRIP_DEBUG=true
+export NO_DEBUGINFO_STRIP_DEBUG=true
+%define __debug_install_post %{nil}
+: >../debugfiles.list
+: >../debugsourcefiles.list
+: >../debugsources.list
+# We want shared libraries to reside in the sysroot but the .so symlinks
+# on the host.  Once we have a cross target that has shared libs we need
+# to manually fix up things here like we do for non-cross compilers
+mkdir -p $RPM_BUILD_ROOT/%{?sysroot:%sysroot}
+make DESTDIR=$RPM_BUILD_ROOT install-target
+%if %{build_cp}
+# So we installed libstdc++ headers into %prefix where they conflict
+# with other host compilers.  Rip out the non-target specific parts
+# again.  Note not all cross targets support libstdc++, so create the
+# directory to make things easier.
+mkdir -p $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version}
+find $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version} -mindepth 1 -maxdepth 1 -type d -a -not -name %{gcc_target_arch} | xargs -r rm -r
+find $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version} -maxdepth 1 -type f | xargs -r rm
+# And also remove installed pretty printers which conflict in similar ways
+rm -rf $RPM_BUILD_ROOT/%{_datadir}/gcc%{binsuffix}
+%endif
+%endif
+%endif
+
+%if 0%{?binutils_os:1}
+for prog in as ld; do
+  ln -s /usr/%{binutils_os}/bin/$prog $RPM_BUILD_ROOT%{targetlibsubdir}/
+done
+%endif
+
+# remove docs
+rm -rf $RPM_BUILD_ROOT%{_mandir}
+rm -rf $RPM_BUILD_ROOT%{_infodir}
+
+# for accelerators remove all frontends but lto1 and also install-tools
+%if 0%{?gcc_accel:1}
+rm -f $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/cc1
+rm -f $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/cc1plus
+rm -rf $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/install-tools
+rm -rf $RPM_BUILD_ROOT%{targetlibsubdir}/install-tools
+# also move things from target directories into the accel path since
+# that is the place where we later search for (only)
+( cd $RPM_BUILD_ROOT%{targetlibsubdir} && tar cf - . ) | ( cd $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch} && tar xf - )
+rm -rf $RPM_BUILD_ROOT%{targetlibsubdir}
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+# Build an icecream environment
+# The assembler comes from the cross-binutils, and hence is _not_
+# named funnily, not even on ppc, so there we need the original target
+install -s -D %{_prefix}/bin/%{binutils_os}-as \
+	$RPM_BUILD_ROOT/env/usr/bin/as
+install -s $RPM_BUILD_ROOT/%{_prefix}/bin/%{gcc_target_arch}-g++%{binsuffix} \
+	$RPM_BUILD_ROOT/env/usr/bin/g++
+install -s $RPM_BUILD_ROOT/%{_prefix}/bin/%{gcc_target_arch}-gcc%{binsuffix} \
+	$RPM_BUILD_ROOT/env/usr/bin/gcc
+
+for back in cc1 cc1plus; do
+	install -s -D $RPM_BUILD_ROOT/%{targetlibsubdir}/$back \
+		$RPM_BUILD_ROOT/env%{targetlibsubdir}/$back
+done
+if test -f $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.so; then
+  install -s -D $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.so \
+		$RPM_BUILD_ROOT/env%{targetlibsubdir}/liblto_plugin.so
+fi
+
+# Make sure to also pull in all shared library requirements for the
+# binaries we put into the environment which is operated by chrooting
+# into it and execing the compiler
+libs=`for bin in $RPM_BUILD_ROOT/env/usr/bin/* $RPM_BUILD_ROOT/env%{targetlibsubdir}/*; do \
+  ldd $bin | sed -n '\,^[^/]*\(/[^ ]*\).*,{ s//\1/; p; }'  ;\
+done | sort -u `
+for lib in $libs; do
+  # Check wether the same library also exists in the parent directory,
+  # and prefer that on the assumption that it is a more generic one.
+  baselib=`echo "$lib" | sed 's,/[^/]*\(/[^/]*\)$,\1,'`
+  test -f "$baselib" && lib=$baselib
+  install -s -D $lib $RPM_BUILD_ROOT/env$lib
+done
+
+cd $RPM_BUILD_ROOT/env
+tar --no-recursion --mtime @${SOURCE_DATE_EPOCH:-$(date +%s)} --format=gnu -cv `find *|LC_ALL=C sort` |\
+  gzip -n9 > ../%{name}_%{_arch}.tar.gz
+cd ..
+mkdir -p usr/share/icecream-envs
+mv %{name}_%{_arch}.tar.gz usr/share/icecream-envs
+rpm -q --changelog glibc >  usr/share/icecream-envs/%{name}_%{_arch}.glibc
+rpm -q --changelog binutils >  usr/share/icecream-envs/%{name}_%{_arch}.binutils
+rm -r env
+%endif
+
+# we provide update-alternatives for selecting a compiler version for
+# crosses
+%if 0%{!?gcc_accel:1}
+mkdir -p %{buildroot}%{_sysconfdir}/alternatives
+for ex in gcc cpp \
+%if %{build_cp}
+          c++ g++ \
+%endif
+          gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool; do
+  ln -s %{_sysconfdir}/alternatives/%{gcc_target_arch}-$ex \
+	%{buildroot}%{_bindir}/%{gcc_target_arch}-$ex
+done
+
+%post
+%{_sbindir}/update-alternatives \
+  --install %{_bindir}/%{gcc_target_arch}-gcc %{gcc_target_arch}-gcc %{_bindir}/%{gcc_target_arch}-gcc%{binsuffix} 7 \
+  --slave %{_bindir}/%{gcc_target_arch}-cpp %{gcc_target_arch}-cpp %{_bindir}/%{gcc_target_arch}-cpp%{binsuffix} \
+%if %{build_cp}
+  --slave %{_bindir}/%{gcc_target_arch}-c++ %{gcc_target_arch}-c++ %{_bindir}/%{gcc_target_arch}-c++%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-g++ %{gcc_target_arch}-g++ %{_bindir}/%{gcc_target_arch}-g++%{binsuffix} \
+%endif
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-ar %{gcc_target_arch}-gcc-ar %{_bindir}/%{gcc_target_arch}-gcc-ar%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-nm %{gcc_target_arch}-gcc-nm %{_bindir}/%{gcc_target_arch}-gcc-nm%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-ranlib %{gcc_target_arch}-gcc-ranlib %{_bindir}/%{gcc_target_arch}-gcc-ranlib%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov %{gcc_target_arch}-gcov %{_bindir}/%{gcc_target_arch}-gcov%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov-dump %{gcc_target_arch}-gcov-dump %{_bindir}/%{gcc_target_arch}-gcov-dump%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov-tool %{gcc_target_arch}-gcov-tool %{_bindir}/%{gcc_target_arch}-gcov-tool%{binsuffix}
+
+%postun
+if [ ! -f %{_bindir}/%{gcc_target_arch}-gcc ] ; then
+  %{_sbindir}/update-alternatives --remove %{gcc_target_arch}-gcc %{_bindir}/%{gcc_target_arch}-gcc%{binsuffix}
+fi
+%endif
+
+%files
+%defattr(-,root,root)
+%if 0%{?gcc_accel:1}
+%{_prefix}/bin/%{GCCDIST}-accel-%{gcc_target_arch}-*
+%dir %{libsubdir}
+%dir %{libsubdir}/accel
+%{libsubdir}/accel/%{gcc_target_arch}
+%else
+%{_prefix}/bin/%{gcc_target_arch}-gcc%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-cpp%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ar%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-nm%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ranlib%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov-dump%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov-tool%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc
+%{_prefix}/bin/%{gcc_target_arch}-cpp
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ar
+%{_prefix}/bin/%{gcc_target_arch}-gcc-nm
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ranlib
+%{_prefix}/bin/%{gcc_target_arch}-gcov
+%{_prefix}/bin/%{gcc_target_arch}-gcov-dump
+%{_prefix}/bin/%{gcc_target_arch}-gcov-tool
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-cpp
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-ar
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-nm
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-ranlib
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov-dump
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov-tool
+%if %{build_cp}
+%{_prefix}/bin/%{gcc_target_arch}-c++%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-g++%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-c++
+%{_prefix}/bin/%{gcc_target_arch}-g++
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-c++
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-g++
+%if 0%{!?gcc_libc_bootstrap:1}
+%if "%{cross_arch}" == "avr" || 0%{?gcc_target_newlib:1} || 0%{?gcc_target_glibc:1}
+%{_prefix}/include/c++
+%endif
+%endif
+%endif
+%dir %{targetlibsubdir}
+%dir %{_libdir}/gcc/%{gcc_target_arch}
+%{targetlibsubdir}
+%endif
+%if 0%{!?gcc_icecream:1} && 0%{!?gcc_libc_bootstrap:1} && 0%{?sysroot:1}
+%{sysroot}
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+%files -n cross-%cross_arch-gcc7-icecream-backend
+%defattr(-,root,root)
+/usr/share/icecream-envs
+%endif
+
+%if 0%{?nvptx_newlib:1}
+%files -n cross-nvptx-newlib7-devel
+%defattr(-,root,root)
+%{_prefix}/%{gcc_target_arch}
+%endif
+
+%changelog

--- a/testing/cross-aarch64-gcc7.spec.out
+++ b/testing/cross-aarch64-gcc7.spec.out
@@ -1,0 +1,928 @@
+#
+# spec file for package cross-aarch64-gcc7
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%define pkgname cross-aarch64-gcc7
+%define cross_arch aarch64
+%define gcc_target_arch aarch64-suse-linux
+%define gcc_icecream 1
+#
+# spec file for package gcc (Version 4.0.1)
+#
+# Copyright (c) 2005 SUSE Linux AG, Nuernberg, Germany.
+# This file and all modifications and additions to the pristine
+# package are under the same license as the package itself.
+#
+# Please submit bugfixes or comments via http://www.suse.de/feedback/
+#
+
+# nospeccleaner
+
+%define build_cp 0%{!?gcc_accel:1}
+%define build_ada 0
+%define build_libjava 0
+%define build_java 0
+
+%define build_fortran 0%{?gcc_accel:1}
+%define build_objc 0
+%define build_objcp 0
+%define build_go 0
+%define build_hsa 0
+%define build_nvptx 0
+
+%define enable_plugins 0
+
+%define binutils_target %{cross_arch}
+%if "%{cross_arch}" == "armv7l" || "%{cross_arch}" == "armv7hl"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "armv6l" || "%{cross_arch}" == "armv6hl"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "armv5tel"
+%define binutils_target arm
+%endif
+%if "%{cross_arch}" == "arm-none"
+%define binutils_target arm
+%define build_cp 0
+%endif
+%if "%{cross_arch}" == "sparcv9"
+%define binutils_target sparc
+%endif
+%define canonical_target %(echo %{binutils_target} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%if "%{binutils_target}" == "avr" || "%{binutils_target}" == "spu"
+%define binutils_os %{canonical_target}
+%else
+%if "%{binutils_target}" == "epiphany" || "%{binutils_target}" == "nds32le" || "%{binutils_target}" == "rl78" || "%{binutils_target}" == "rx"
+%define binutils_os %{canonical_target}-elf
+%else
+%if "%{binutils_target}" == "arm"
+%define binutils_os %{canonical_target}-suse-linux-gnueabi
+%else
+%if 0%{?gcc_accel:1}
+%define binutils_os %{gcc_target_arch}
+%else
+%define binutils_os %{canonical_target}-suse-linux
+%endif
+%endif
+%endif
+%endif
+
+%if 0%{?gcc_icecream:1}
+%define sysroot %{_prefix}/%{gcc_target_arch}
+%else
+# offloading builds newlib in-tree and can install in
+# the GCC private path without extra sysroot
+%if 0%{!?gcc_accel:1}
+# use same sysroot as in binutils.spec
+%define sysroot %{_prefix}/%{binutils_os}/sys-root
+%endif
+%endif
+
+%if %{suse_version} >= 1220
+%define selfconflict() %1
+%else
+%define selfconflict() otherproviders(%1)
+%endif
+
+Name:           %{pkgname}
+%define biarch_targets x86_64 s390x powerpc64 powerpc sparc sparc64
+
+URL:            https://gcc.gnu.org/
+Version:        7.5.0+r278197
+Release:        0
+%define gcc_dir_version %(echo %version | sed 's/+.*//' | cut -d '.' -f 1)
+%define gcc_snapshot_revision %(echo %version | sed 's/[3-9]\.[0-9]\.[0-6]//' | sed 's/+/-/')
+%define binsuffix -7
+Group:          Development/Languages/C and C++
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+Source:         gcc-%{version}.tar.xz
+Source1:        change_spec
+Source3:        gcc7-rpmlintrc
+Source4:        README.First-for.SuSE.packagers
+Source5:        nvptx-newlib.tar.xz
+Patch2:         gcc-add-defaultsspec.diff
+Patch5:         tls-no-direct.diff
+Patch6:         gcc43-no-unwind-tables.diff
+Patch7:         gcc48-libstdc++-api-reference.patch
+Patch9:         gcc48-remove-mpfr-2.4.0-requirement.patch
+Patch10:        gcc5-no-return-gcc43-workaround.patch
+Patch11:        gcc7-remove-Wexpansion-to-defined-from-Wextra.patch
+Patch12:        gcc7-stack-probe.diff
+Patch14:        gcc7-pr82248.diff
+Patch15:        gcc7-avoid-fixinc-error.diff
+Patch17:        gcc7-flive-patching.patch
+Patch18:        gcc7-bsc1146475.patch
+Patch19:        gcc7-pr85887.patch
+Patch20:        gcc7-bsc1160086.patch
+Patch21:        gcc7-pr92154.patch
+Patch22:        gcc7-pr93246.patch
+Patch23:        gcc7-pr92692.patch
+Patch24:        gcc48-bsc1161913.patch
+Patch25:        gcc7-pr93965.patch
+Patch26:        gcc7-pr93888.patch
+Patch27:        gcc7-pr94148.patch
+Patch29:        gcc7-pr97535.patch
+Patch30:        gcc7-pr88522.patch
+Patch31:        gcc7-testsuite-fixes.patch
+Patch32:        gcc7-pr81942.patch
+Patch33:        gcc7-sanitizer-cyclades.patch
+Patch34:        gcc7-ada-MINSTKSZ.patch
+Patch35:        gcc7-pr55917.patch
+Patch36:        gcc7-ada-Target_Name.patch
+Patch37:        gcc7-pr78263.patch
+Patch38:        gcc7-libsanitizer-cherry-pick-9cf13067cb5088626ba7-from-u.patch
+Patch39:        gcc7-libgo-don-t-include-linux-fs.h-when-building-gen-sys.patch
+Patch40:        gcc7-pr72764.patch
+Patch41:        gcc7-pr89124.patch
+Patch42:        libgcc-riscv-div.patch
+Patch43:        gcc7-aarch64-bsc1214052.patch
+Patch44:        gcc7-aarch64-untyped_call.patch
+Patch45:        gcc7-lra-elim.patch
+Patch46:        gcc7-bsc1216488.patch
+Patch47:        gcc7-pr87723.patch
+# A set of patches from the RH srpm
+Patch51:        gcc41-ppc32-retaddr.patch
+# Some patches taken from Debian
+Patch60:        gcc44-textdomain.patch
+Patch61:        gcc44-rename-info-files.patch
+# Feature backports
+Patch100:       gcc7-aarch64-moutline-atomics.patch
+Patch101:       gcc7-fix-retrieval-of-testnames.patch
+Patch102:       gcc7-aarch64-sls-miti-1.patch
+Patch103:       gcc7-aarch64-sls-miti-2.patch
+Patch104:       gcc7-aarch64-sls-miti-3.patch
+Patch105:       gcc7-pfe-0001-Backport-Add-entry-for-patchable_function_entry.patch
+Patch106:       gcc7-pfe-0002-Backport-Skip-fpatchable-function-entry-tests-for-nv.patch
+Patch107:       gcc7-pfe-0003-Backport-Error-out-on-nvptx-for-fpatchable-function-.patch
+Patch108:       gcc7-pfe-0004-Backport-Adapt-scan-assembler-times-for-alpha.patch
+Patch109:       gcc7-pfe-0005-Backport-patchable_function_entry-decl.c-Use-3-NOPs-.patch
+Patch110:       gcc7-pfe-0006-Backport-IBM-Z-Use-the-dedicated-NOP-instructions-fo.patch
+Patch111:       gcc7-pfe-0007-Backport-Add-regex-to-search-for-uppercase-NOP-instr.patch
+Patch112:       gcc7-pfe-0008-Backport-ICE-segmentation-fault-with-patchable_funct.patch
+Patch113:       gcc7-pfe-0009-Backport-patchable_function_entry-decl.c-Pass-mcpu-g.patch
+Patch114:       gcc7-pfe-0010-Backport-patchable_function_entry-decl.c-Do-not-run-.patch
+Patch115:       gcc7-pfe-0011-Backport-patchable_function_entry-decl.c-Add-fno-pie.patch
+Patch116:       gcc7-pfe-0012-Backport-PR-c-89946-ICE-in-assemble_start_function-a.patch
+Patch117:       gcc7-pfe-0013-Backport-targhooks.c-default_print_patchable_functio.patch
+Patch118:       gcc7-pfe-0014-Backport-Align-__patchable_function_entries-to-POINT.patch
+Patch119:       gcc7-pfe-0015-Backport-Fix-PR-93242-patchable-function-entry-broke.patch
+Patch120:       gcc7-pfe-0016-Backport-Fix-patchable-function-entry-on-arc.patch
+Patch121:       gcc7-pfe-0017-Backport-Add-patch_area_size-and-patch_area_entry-to.patch
+Patch122:       gcc7-pfe-0018-Backport-testsuite-Adjust-patchable_function-tests-f.patch
+Patch123:       gcc7-pfe-0019-Backport-Use-the-section-flag-o-for-__patchable_func.patch
+Patch124:       gcc7-pfe-0020-Backport-varasm-Fix-up-__patchable_function_entries-.patch
+Patch125:       gcc7-pfe-0021-Backport-rs6000-Avoid-fpatchable-function-entry-regr.patch
+Patch126:       gcc7-pfe-0022-Fix-unwinding-issues-when-pfe-is-enabled.patch
+Patch127:       gcc7-pr88345-min-func-alignment.diff
+
+# Define the canonical target and host architecture
+#   %%gcc_target_arch  is supposed to be the full target triple
+#   %%cross_arch       is supposed to be the rpm target variant arch
+#   %%TARGET_ARCH      will be the canonicalized target CPU part
+#   %%HOST_ARCH        will be the canonicalized host CPU part
+%if 0%{?gcc_target_arch:1}
+%define TARGET_ARCH %(echo %{cross_arch} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%else
+%define TARGET_ARCH %(echo %{_target_cpu} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%endif
+%if 0%{?disable_32bit:1}
+%define biarch 0
+%else
+%define biarch %(case " %{biarch_targets} " in (*" %{TARGET_ARCH} "*) echo 1;; (*) echo 0;; esac)
+%endif
+
+%define HOST_ARCH %(echo %{_target_cpu} | sed -e "s/i.86/i586/;s/ppc/powerpc/;s/sparc64.*/sparc64/;s/sparcv.*/sparc/;")
+%ifarch ppc
+%define GCCDIST powerpc64-suse-linux
+%else
+%ifarch %sparc
+%define GCCDIST sparc64-suse-linux
+%else
+%ifarch %arm
+%define GCCDIST %{HOST_ARCH}-suse-linux-gnueabi
+%else
+%define GCCDIST %{HOST_ARCH}-suse-linux
+%endif
+%endif
+%endif
+
+%define libsubdir %{_libdir}/gcc/%{GCCDIST}/%{gcc_dir_version}
+%define gxxinclude %{_prefix}/include/c++/%{gcc_dir_version}
+
+%if "%{cross_arch}" != "nvptx"
+BuildRequires:  cross-%{binutils_target}-binutils
+Requires:       cross-%{binutils_target}-binutils
+%endif
+BuildRequires:  bison
+BuildRequires:  flex
+BuildRequires:  gcc-c++
+BuildRequires:  gettext-devel
+BuildRequires:  glibc-devel-32bit
+BuildRequires:  mpc-devel
+BuildRequires:  mpfr-devel
+BuildRequires:  perl
+%if %{suse_version} > 1220
+BuildRequires:  makeinfo
+%else
+BuildRequires:  texinfo
+%endif
+BuildRequires:  zlib-devel
+%ifarch %ix86 x86_64 ppc ppc64 s390 s390x ia64 %sparc hppa %arm
+BuildRequires:  isl-devel
+%endif
+%ifarch ia64
+BuildRequires:  libunwind-devel
+%endif
+%if 0%{!?gcc_icecream:1}
+%if 0%{?gcc_target_newlib:1} && 0%{!?gcc_libc_bootstrap:1}
+BuildRequires:  cross-%cross_arch-newlib-devel
+%endif
+%if 0%{!?gcc_libc_bootstrap:1} && "%{cross_arch}" == "avr"
+BuildRequires:  avr-libc
+%endif
+%if 0%{?gcc_target_glibc:1}
+BuildRequires:  cross-%cross_arch-glibc-devel
+%endif
+%if "%{cross_arch}" == "nvptx"
+BuildRequires:  nvptx-tools
+Requires:       cross-nvptx-newlib-devel >= %{version}-%{release}
+Requires:       nvptx-tools
+ExclusiveArch:  x86_64
+%define nvptx_newlib 1
+%endif
+%endif
+%if 0%{?gcc_icecream:1}
+ExclusiveArch:  ppc64le ppc64 x86_64 s390x
+%endif
+%define _binary_payload w.ufdio
+# Obsolete cross-ppc-gcc49 from cross-ppc64-gcc49 which has
+# file conflicts with it and is no longer packaged
+%if "%pkgname" == "cross-ppc64-gcc49"
+Obsoletes:      cross-ppc-gcc49 <= 4.9.0+r209354
+%endif
+%if 0%{?gcc_target_newlib:1}
+# Generally only one cross for the same target triplet can be installed
+# at the same time as we are populating a non-version-specific sysroot
+Provides:       %{gcc_target_arch}-gcc
+Conflicts:      %selfconflict %{gcc_target_arch}-gcc
+%endif
+%if 0%{?gcc_libc_bootstrap:1}
+# The -bootstrap packages file-conflict with the non-bootstrap variants.
+# Even if we don't actually (want to) distribute the bootstrap variants
+# the following avoids repo-checker spamming us endlessly.
+Conflicts:      cross-%{cross_arch}-gcc7
+%endif
+#!BuildIgnore: gcc-PIE
+BuildRequires:  update-alternatives
+Requires(post): update-alternatives
+Requires(preun): update-alternatives
+Summary:        The GNU Compiler Collection targeting %{cross_arch}
+License:        GPL-3.0-or-later
+
+%description
+The GNU Compiler Collection as a cross-compiler targeting %{cross_arch}.
+%if 0%{?gcc_icecream:1}
+Note this is only useful for building freestanding things like the
+kernel since it fails to include target libraries and headers.
+%endif
+%if 0%{?gcc_libc_bootstrap:1}
+This is a package that is necessary for bootstrapping another package
+only, it is not intended for any other use.
+%endif
+
+%prep
+%if 0%{?nvptx_newlib:1}
+%setup -q -n gcc-%{version} -a 5
+ln -s nvptx-newlib/newlib .
+%else
+%setup -q -n gcc-%{version}
+%endif
+
+#test patching start
+
+%patch -P 2
+%patch -P 5
+%patch -P 6
+%patch -P 7
+%if %{suse_version} < 1310
+%patch -P 9
+%endif
+%patch -P 10
+%patch -P 11
+%patch -P 12
+%patch -P 14
+%patch -P 15
+%patch -P 17 -p1
+%patch -P 18
+%patch -P 19
+%patch -P 20
+%patch -P 21 -p1
+%patch -P 22 -p1
+%patch -P 24 -p1
+%patch -P 25 -p1
+%patch -P 26 -p1
+%patch -P 27 -p1
+%patch -P 29
+%patch -P 30 -p1
+%patch -P 31 -p1
+%patch -P 32 -p1
+%patch -P 33 -p1
+%patch -P 34 -p1
+%patch -P 35 -p1
+%patch -P 36 -p1
+%patch -P 37 -p1
+%patch -P 38 -p1
+%patch -P 39 -p1
+%patch -P 40 -p1
+%patch -P 41 -p1
+%patch -P 42 -p1
+%patch -P 43 -p1
+%patch -P 44 -p1
+%patch -P 45 -p1
+%patch -P 46 -p1
+%patch -P 47 -p1
+%patch -P 51
+%patch -P 60
+%patch -P 61
+%patch -P 100 -p1
+%patch -P 23 -p1
+%patch -P 101 -p1
+%patch -P 102 -p1
+%patch -P 103 -p1
+%patch -P 104 -p1
+%patch -P 105 -p1
+%patch -P 106 -p1
+%patch -P 107 -p1
+%patch -P 108 -p1
+%patch -P 109 -p1
+%patch -P 110 -p1
+%patch -P 111 -p1
+%patch -P 112 -p1
+%patch -P 113 -p1
+%patch -P 114 -p1
+%patch -P 115 -p1
+%patch -P 116 -p1
+%patch -P 117 -p1
+%patch -P 118 -p1
+%patch -P 119 -p1
+%patch -P 120 -p1
+%patch -P 121 -p1
+%patch -P 122 -p1
+%patch -P 123 -p1
+%patch -P 124 -p1
+%patch -P 125 -p1
+%patch -P 126 -p1
+%patch -P 127 -p1
+
+#test patching end
+
+%build
+%define _lto_cflags %{nil}
+# Avoid rebuilding of generated files
+contrib/gcc_update --touch
+
+# SLE11 does not allow empty rpms
+%if %{suse_version} < 1310
+echo "This is a dummy package to provide a dependency." > README
+%endif
+
+rm -rf obj-%{GCCDIST}
+mkdir obj-%{GCCDIST}
+cd obj-%{GCCDIST}
+RPM_OPT_FLAGS="$RPM_OPT_FLAGS -U_FORTIFY_SOURCE"
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-fno-rtti//g' -e 's/-fno-exceptions//g' -e 's/-Wmissing-format-attribute//g' -e 's/-fstack-protector[^ ]*//g' -e 's/-ffortify=.//g' -e 's/-Wall//g' -e 's/-m32//g' -e 's/-m64//g'`
+%ifarch %ix86
+# -mcpu is superceded by -mtune but -mtune is not supported by
+# our bootstrap compiler.  -mcpu gives a warning that stops
+# the build process, so remove it for now.  Also remove all other
+# -march and -mtune flags.  They are superseeded by proper
+# default compiler settings now.
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-mcpu=i.86//g' -e 's/-march=i.86//g' -e 's/-mtune=i.86//g'`
+%endif
+%ifarch s390 s390x
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-fsigned-char//g'`
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-O1/-O2/g'`
+%endif
+%ifarch aarch64
+%if %{build_ada}
+# -mbranch-protection=standard flag is unsupported in gcc7 and we use GCC7 to build GCC7
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-mbranch-protection=standard//g'`
+%endif
+%endif
+%if 0%{?gcc_target_arch:1}
+# Kill all -march/tune/cpu because that screws building the target libs
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/-m\(arch\|tune\|cpu\)=[^ ]*//g'`
+%endif
+# Replace 2 spaces by one finally
+RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS|sed -e 's/  / /g'`
+
+languages=c
+%if %{build_cp}
+languages=$languages,c++
+%endif
+%if %{build_objc}
+languages=$languages,objc
+%endif
+%if %{build_fortran}
+languages=$languages,fortran
+%endif
+%if %{build_objcp}
+languages=$languages,obj-c++
+%endif
+%if %{build_ada}
+languages=$languages,ada
+%endif
+%if %{build_go}
+languages=$languages,go
+%endif
+
+# In general we want to ship release checking enabled compilers
+# which is the default for released compilers
+#ENABLE_CHECKING="--enable-checking=yes"
+ENABLE_CHECKING="--enable-checking=release"
+#ENABLE_CHECKING=""
+
+# Work around tail/head -1 changes
+export _POSIX2_VERSION=199209
+
+%if %{build_ada}
+# Using the host gnatmake like
+#   CC="gcc%%{hostsuffix}" GNATBIND="gnatbind%%{hostsuffix}"
+#   GNATMAKE="gnatmake%%{hostsuffix}"
+# doesn't work due to PR33857, so an un-suffixed gnatmake has to be
+# available
+mkdir -p host-tools/bin
+cp -a /usr/bin/gnatmake%{hostsuffix} host-tools/bin/gnatmake
+cp -a /usr/bin/gnatlink%{hostsuffix} host-tools/bin/gnatlink
+cp -a /usr/bin/gnatbind%{hostsuffix} host-tools/bin/gnatbind
+cp -a /usr/bin/gcc%{hostsuffix} host-tools/bin/gcc
+cp -a /usr/bin/g++%{hostsuffix} host-tools/bin/g++
+ln -sf /usr/%{_lib} host-tools/%{_lib}
+export PATH="`pwd`/host-tools/bin:$PATH"
+%endif
+CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS" XCFLAGS="$RPM_OPT_FLAGS" \
+TCFLAGS="$RPM_OPT_FLAGS" \
+../configure \
+	--prefix=%{_prefix} \
+	--infodir=%{_infodir} \
+	--mandir=%{_mandir} \
+	--libdir=%{_libdir} \
+	--libexecdir=%{_libdir} \
+	--enable-languages=$languages \
+%if %{build_hsa} || %{build_nvptx}
+	--enable-offload-targets=\
+%if %{build_hsa}
+hsa,\
+%endif
+%if %{build_nvptx}
+nvptx-none, \
+%endif
+%endif
+%if %{build_nvptx}
+	--without-cuda-driver \
+%endif
+	$ENABLE_CHECKING \
+	--disable-werror \
+	--with-gxx-include-dir=%{_prefix}/include/c++/%{gcc_dir_version} \
+	--enable-ssp \
+	--disable-libssp \
+%if 0%{!?build_libvtv:1}
+	--disable-libvtv \
+%endif
+%ifnarch %mpx_arch
+	--disable-libmpx \
+%endif
+	--disable-libcc1 \
+%if %{enable_plugins}
+	--enable-plugin \
+%else
+	--disable-plugin \
+%endif
+	--with-bugurl="https://bugs.opensuse.org/" \
+	--with-pkgversion="SUSE Linux" \
+	--with-slibdir=/%{_lib} \
+	--with-system-zlib \
+	--enable-libstdcxx-allocator=new \
+	--disable-libstdcxx-pch \
+%if 0%{suse_version} <= 1320
+	--with-default-libstdcxx-abi=gcc4-compatible \
+%endif
+	--enable-version-specific-runtime-libs \
+	--with-gcc-major-version-only \
+	--enable-linker-build-id \
+	--enable-linux-futex \
+%if %{suse_version} >= 1315
+%ifarch %ix86 x86_64 ppc ppc64 ppc64le %arm aarch64 s390 s390x %sparc
+	--enable-gnu-indirect-function \
+%endif
+%endif
+	--program-suffix=%{binsuffix} \
+%if 0%{?disable_32bit:1}
+	--disable-multilib \
+%endif
+%if 0%{!?gcc_target_arch:1}
+%ifarch ia64
+	--with-system-libunwind \
+%else
+	--without-system-libunwind \
+%endif
+%endif
+%if 0%{?gcc_target_arch:1}
+	--program-prefix=%{gcc_target_arch}- \
+	--target=%{gcc_target_arch} \
+	--disable-nls \
+%if 0%{?sysroot:1}
+	--with-sysroot=%sysroot \
+%endif
+%if 0%{?build_sysroot:1}
+	--with-build-sysroot=%{build_sysroot} \
+%else
+%if 0%{?sysroot:1}
+	--with-build-sysroot=%{sysroot} \
+%endif
+%endif
+%if 0%{?binutils_os:1}
+	--with-build-time-tools=/usr/%{binutils_os}/bin \
+%endif
+%if 0%{?gcc_target_newlib}
+	--with-newlib \
+%if 0%{?gcc_libc_bootstrap:1}
+	--without-headers \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "spu"
+	--with-gxx-include-dir=%sysroot/include/c++/%{gcc_dir_version} \
+	--with-newlib \
+%endif
+%if "%{TARGET_ARCH}" == "nvptx"
+	--enable-as-accelerator-for=%{GCCDIST} \
+	--disable-sjlj-exceptions \
+	--enable-newlib-io-long-long \
+%endif
+%if "%{TARGET_ARCH}" == "avr"
+	--enable-lto \
+	--without-gxx-include-dir \
+	--with-native-system-header-dir=/include \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "arm"
+        --with-arch=armv6zk \
+        --with-tune=arm1176jzf-s \
+	--with-float=hard \
+	--with-abi=aapcs-linux \
+	--with-fpu=vfp \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv5tel"
+	--with-arch=armv5te \
+	--with-float=soft \
+	--with-mode=arm \
+	--with-abi=aapcs-linux \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv6hl"
+        --with-arch=armv6zk \
+        --with-tune=arm1176jzf-s \
+        --with-float=hard \
+        --with-abi=aapcs-linux \
+        --with-fpu=vfp \
+        --disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "armv7hl"
+	--with-arch=armv7-a \
+	--with-tune=cortex-a15 \
+	--with-float=hard \
+	--with-abi=aapcs-linux \
+	--with-fpu=vfpv3-d16 \
+	--disable-sjlj-exceptions \
+%endif
+%if "%{TARGET_ARCH}" == "aarch64"
+	--enable-fix-cortex-a53-835769 \
+	--enable-fix-cortex-a53-843419 \
+%endif
+%if "%{TARGET_ARCH}" == "powerpc" || "%{TARGET_ARCH}" == "powerpc64" || "%{TARGET_ARCH}" == "powerpc64le"
+%if "%{TARGET_ARCH}" == "powerpc"
+        --with-cpu=default32 \
+%endif
+%if "%{TARGET_ARCH}" == "powerpc64le"
+%if %{suse_version} >= 1350
+	--with-cpu=power8 \
+	--with-tune=power9 \
+%else
+%if %{suse_version} >= 1315 && %{suse_version} != 1320
+	--with-cpu=power8 \
+	--with-tune=power8 \
+%else
+	--with-cpu=power7 \
+	--with-tune=power7 \
+%endif
+%endif
+%else
+	--with-cpu-64=power4 \
+%endif
+	--enable-secureplt \
+	--with-long-double-128 \
+%if "%{TARGET_ARCH}" == "powerpc64le"
+	--enable-targets=powerpcle-linux \
+	--disable-multilib \
+%endif
+%endif
+%if "%{TARGET_ARCH}" == "sparc64"
+	--with-cpu=ultrasparc \
+	--with-long-double-128 \
+%endif
+%if "%{TARGET_ARCH}" == "sparc"
+	--with-cpu=v8 \
+	--with-long-double-128 \
+%endif
+%if "%{TARGET_ARCH}" == "i586"
+%if 0%{?sle_version:%sle_version} >= 150000
+	--with-arch-32=x86-64 \
+%else
+	--with-arch-32=i586 \
+%endif
+	--with-tune=generic \
+%endif
+%if "%{TARGET_ARCH}" == "x86_64"
+	--enable-multilib \
+	--with-arch-32=x86-64 \
+	--with-tune=generic \
+%endif
+%if "%{TARGET_ARCH}" == "s390"
+%if %{suse_version} >= 1310
+        --with-tune=zEC12 --with-arch=z196 \
+%else
+	--with-tune=z9-109 --with-arch=z900 \
+%endif
+	--with-long-double-128 \
+	--enable-decimal-float \
+%endif
+%if "%{TARGET_ARCH}" == "s390x"
+%if %{suse_version} >= 1310
+        --with-tune=zEC12 --with-arch=z196 \
+%else
+	--with-tune=z9-109 --with-arch=z900 \
+%endif
+	--with-long-double-128 \
+	--enable-decimal-float \
+%endif
+%if "%{TARGET_ARCH}" == "m68k"
+	--disable-multilib \
+%endif
+%if "%{TARGET_ARCH}" == "riscv64"
+	--disable-multilib \
+%endif
+	--build=%{GCCDIST} \
+	--host=%{GCCDIST}
+
+%if 0%{!?gcc_icecream:1} && 0%{!?gcc_libc_bootstrap:1}
+make %{?_smp_mflags}
+%else
+make %{?_smp_mflags} all-host
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+%package -n cross-%cross_arch-gcc7-icecream-backend
+Summary:        Icecream backend for the GNU C Compiler
+Group:          Development/Languages/C and C++
+
+%description -n cross-%cross_arch-gcc7-icecream-backend
+This package contains the icecream environment for the GNU C Compiler
+%endif
+
+%if 0%{?nvptx_newlib:1}
+%package -n cross-nvptx-newlib7-devel
+Summary:        newlib for the nvptx offload target
+Group:          Development/Languages/C and C++
+Provides:       cross-nvptx-newlib-devel = %{version}-%{release}
+Conflicts:      cross-nvptx-newlib-devel
+
+%description -n cross-nvptx-newlib7-devel
+Newlib development files for the nvptx offload target compiler.
+%endif
+
+%define targetlibsubdir %{_libdir}/gcc/%{gcc_target_arch}/%{gcc_dir_version}
+
+%install
+cd obj-%{GCCDIST}
+
+# install and fixup host parts
+make DESTDIR=$RPM_BUILD_ROOT install-host
+rm -rf $RPM_BUILD_ROOT/%{targetlibsubdir}/install-tools
+rm -f $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.la
+# common fixup
+rm -f $RPM_BUILD_ROOT%{_libdir}/libiberty.a
+
+# install and fixup target parts
+# debugedit is not prepared for this and crashes
+%if 0%{?gcc_icecream:1}
+# so expect the sysroot to be populated from natively built binaries
+%else
+%if 0%{!?gcc_libc_bootstrap:1}
+export NO_BRP_STRIP_DEBUG=true
+export NO_DEBUGINFO_STRIP_DEBUG=true
+%define __debug_install_post %{nil}
+: >../debugfiles.list
+: >../debugsourcefiles.list
+: >../debugsources.list
+# We want shared libraries to reside in the sysroot but the .so symlinks
+# on the host.  Once we have a cross target that has shared libs we need
+# to manually fix up things here like we do for non-cross compilers
+mkdir -p $RPM_BUILD_ROOT/%{?sysroot:%sysroot}
+make DESTDIR=$RPM_BUILD_ROOT install-target
+%if %{build_cp}
+# So we installed libstdc++ headers into %prefix where they conflict
+# with other host compilers.  Rip out the non-target specific parts
+# again.  Note not all cross targets support libstdc++, so create the
+# directory to make things easier.
+mkdir -p $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version}
+find $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version} -mindepth 1 -maxdepth 1 -type d -a -not -name %{gcc_target_arch} | xargs -r rm -r
+find $RPM_BUILD_ROOT/%_prefix/include/c++/%{gcc_dir_version} -maxdepth 1 -type f | xargs -r rm
+# And also remove installed pretty printers which conflict in similar ways
+rm -rf $RPM_BUILD_ROOT/%{_datadir}/gcc%{binsuffix}
+%endif
+%endif
+%endif
+
+%if 0%{?binutils_os:1}
+for prog in as ld; do
+  ln -s /usr/%{binutils_os}/bin/$prog $RPM_BUILD_ROOT%{targetlibsubdir}/
+done
+%endif
+
+# remove docs
+rm -rf $RPM_BUILD_ROOT%{_mandir}
+rm -rf $RPM_BUILD_ROOT%{_infodir}
+
+# for accelerators remove all frontends but lto1 and also install-tools
+%if 0%{?gcc_accel:1}
+rm -f $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/cc1
+rm -f $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/cc1plus
+rm -rf $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch}/install-tools
+rm -rf $RPM_BUILD_ROOT%{targetlibsubdir}/install-tools
+# also move things from target directories into the accel path since
+# that is the place where we later search for (only)
+( cd $RPM_BUILD_ROOT%{targetlibsubdir} && tar cf - . ) | ( cd $RPM_BUILD_ROOT%{libsubdir}/accel/%{gcc_target_arch} && tar xf - )
+rm -rf $RPM_BUILD_ROOT%{targetlibsubdir}
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+# Build an icecream environment
+# The assembler comes from the cross-binutils, and hence is _not_
+# named funnily, not even on ppc, so there we need the original target
+install -s -D %{_prefix}/bin/%{binutils_os}-as \
+	$RPM_BUILD_ROOT/env/usr/bin/as
+install -s $RPM_BUILD_ROOT/%{_prefix}/bin/%{gcc_target_arch}-g++%{binsuffix} \
+	$RPM_BUILD_ROOT/env/usr/bin/g++
+install -s $RPM_BUILD_ROOT/%{_prefix}/bin/%{gcc_target_arch}-gcc%{binsuffix} \
+	$RPM_BUILD_ROOT/env/usr/bin/gcc
+
+for back in cc1 cc1plus; do
+	install -s -D $RPM_BUILD_ROOT/%{targetlibsubdir}/$back \
+		$RPM_BUILD_ROOT/env%{targetlibsubdir}/$back
+done
+if test -f $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.so; then
+  install -s -D $RPM_BUILD_ROOT/%{targetlibsubdir}/liblto_plugin.so \
+		$RPM_BUILD_ROOT/env%{targetlibsubdir}/liblto_plugin.so
+fi
+
+# Make sure to also pull in all shared library requirements for the
+# binaries we put into the environment which is operated by chrooting
+# into it and execing the compiler
+libs=`for bin in $RPM_BUILD_ROOT/env/usr/bin/* $RPM_BUILD_ROOT/env%{targetlibsubdir}/*; do \
+  ldd $bin | sed -n '\,^[^/]*\(/[^ ]*\).*,{ s//\1/; p; }'  ;\
+done | sort -u `
+for lib in $libs; do
+  # Check wether the same library also exists in the parent directory,
+  # and prefer that on the assumption that it is a more generic one.
+  baselib=`echo "$lib" | sed 's,/[^/]*\(/[^/]*\)$,\1,'`
+  test -f "$baselib" && lib=$baselib
+  install -s -D $lib $RPM_BUILD_ROOT/env$lib
+done
+
+cd $RPM_BUILD_ROOT/env
+tar --no-recursion --mtime @${SOURCE_DATE_EPOCH:-$(date +%s)} --format=gnu -cv `find *|LC_ALL=C sort` |\
+  gzip -n9 > ../%{name}_%{_arch}.tar.gz
+cd ..
+mkdir -p usr/share/icecream-envs
+mv %{name}_%{_arch}.tar.gz usr/share/icecream-envs
+rpm -q --changelog glibc >  usr/share/icecream-envs/%{name}_%{_arch}.glibc
+rpm -q --changelog binutils >  usr/share/icecream-envs/%{name}_%{_arch}.binutils
+rm -r env
+%endif
+
+# we provide update-alternatives for selecting a compiler version for
+# crosses
+%if 0%{!?gcc_accel:1}
+mkdir -p %{buildroot}%{_sysconfdir}/alternatives
+for ex in gcc cpp \
+%if %{build_cp}
+          c++ g++ \
+%endif
+          gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool; do
+  ln -s %{_sysconfdir}/alternatives/%{gcc_target_arch}-$ex \
+	%{buildroot}%{_bindir}/%{gcc_target_arch}-$ex
+done
+
+%post
+%{_sbindir}/update-alternatives \
+  --install %{_bindir}/%{gcc_target_arch}-gcc %{gcc_target_arch}-gcc %{_bindir}/%{gcc_target_arch}-gcc%{binsuffix} 7 \
+  --slave %{_bindir}/%{gcc_target_arch}-cpp %{gcc_target_arch}-cpp %{_bindir}/%{gcc_target_arch}-cpp%{binsuffix} \
+%if %{build_cp}
+  --slave %{_bindir}/%{gcc_target_arch}-c++ %{gcc_target_arch}-c++ %{_bindir}/%{gcc_target_arch}-c++%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-g++ %{gcc_target_arch}-g++ %{_bindir}/%{gcc_target_arch}-g++%{binsuffix} \
+%endif
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-ar %{gcc_target_arch}-gcc-ar %{_bindir}/%{gcc_target_arch}-gcc-ar%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-nm %{gcc_target_arch}-gcc-nm %{_bindir}/%{gcc_target_arch}-gcc-nm%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcc-ranlib %{gcc_target_arch}-gcc-ranlib %{_bindir}/%{gcc_target_arch}-gcc-ranlib%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov %{gcc_target_arch}-gcov %{_bindir}/%{gcc_target_arch}-gcov%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov-dump %{gcc_target_arch}-gcov-dump %{_bindir}/%{gcc_target_arch}-gcov-dump%{binsuffix} \
+  --slave %{_bindir}/%{gcc_target_arch}-gcov-tool %{gcc_target_arch}-gcov-tool %{_bindir}/%{gcc_target_arch}-gcov-tool%{binsuffix}
+
+%postun
+if [ ! -f %{_bindir}/%{gcc_target_arch}-gcc ] ; then
+  %{_sbindir}/update-alternatives --remove %{gcc_target_arch}-gcc %{_bindir}/%{gcc_target_arch}-gcc%{binsuffix}
+fi
+%endif
+
+%files
+%defattr(-,root,root)
+%if 0%{?gcc_accel:1}
+%{_prefix}/bin/%{GCCDIST}-accel-%{gcc_target_arch}-*
+%dir %{libsubdir}
+%dir %{libsubdir}/accel
+%{libsubdir}/accel/%{gcc_target_arch}
+%else
+%{_prefix}/bin/%{gcc_target_arch}-gcc%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-cpp%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ar%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-nm%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ranlib%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov-dump%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcov-tool%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-gcc
+%{_prefix}/bin/%{gcc_target_arch}-cpp
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ar
+%{_prefix}/bin/%{gcc_target_arch}-gcc-nm
+%{_prefix}/bin/%{gcc_target_arch}-gcc-ranlib
+%{_prefix}/bin/%{gcc_target_arch}-gcov
+%{_prefix}/bin/%{gcc_target_arch}-gcov-dump
+%{_prefix}/bin/%{gcc_target_arch}-gcov-tool
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-cpp
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-ar
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-nm
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcc-ranlib
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov-dump
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-gcov-tool
+%if %{build_cp}
+%{_prefix}/bin/%{gcc_target_arch}-c++%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-g++%{binsuffix}
+%{_prefix}/bin/%{gcc_target_arch}-c++
+%{_prefix}/bin/%{gcc_target_arch}-g++
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-c++
+%ghost %{_sysconfdir}/alternatives/%{gcc_target_arch}-g++
+%if 0%{!?gcc_libc_bootstrap:1}
+%if "%{cross_arch}" == "avr" || 0%{?gcc_target_newlib:1} || 0%{?gcc_target_glibc:1}
+%{_prefix}/include/c++
+%endif
+%endif
+%endif
+%dir %{targetlibsubdir}
+%dir %{_libdir}/gcc/%{gcc_target_arch}
+%{targetlibsubdir}
+%endif
+%if 0%{!?gcc_icecream:1} && 0%{!?gcc_libc_bootstrap:1} && 0%{?sysroot:1}
+%{sysroot}
+%endif
+
+%if 0%{?gcc_icecream:%gcc_icecream}
+%files -n cross-%cross_arch-gcc7-icecream-backend
+%defattr(-,root,root)
+/usr/share/icecream-envs
+%endif
+
+%if 0%{?nvptx_newlib:1}
+%files -n cross-nvptx-newlib7-devel
+%defattr(-,root,root)
+%{_prefix}/%{gcc_target_arch}
+%endif
+
+%changelog

--- a/testing/cross-aarch64-gcc7.spec.out
+++ b/testing/cross-aarch64-gcc7.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package cross-aarch64-gcc7
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/defattr.spec.out
+++ b/testing/defattr.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package defattr
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/deprecatedgrep.spec.out
+++ b/testing/deprecatedgrep.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package deprecatedgrep
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/depredux.spec.out
+++ b/testing/depredux.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package depredux
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/description.spec.out
+++ b/testing/description.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package description
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/desctopreamble.spec.out
+++ b/testing/desctopreamble.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package desctopreamble
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/doc2license.spec.out
+++ b/testing/doc2license.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package doc2license
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/dos2unix.spec.out
+++ b/testing/dos2unix.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package dos2unix
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/enhances.spec.out
+++ b/testing/enhances.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package enhances
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/excludearch.spec.out
+++ b/testing/excludearch.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package excludearch
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/excludes-bracketing.spec.out
+++ b/testing/excludes-bracketing.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package excludes-bracketing
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/filesattr.spec.out
+++ b/testing/filesattr.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package filesattr
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/fileswhitespace.spec.out
+++ b/testing/fileswhitespace.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package fileswhitespace
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/fixme-with-space.spec.out
+++ b/testing/fixme-with-space.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package fixme-with-space
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/gdb.spec.out
+++ b/testing/gdb.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package gdb
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 # Copyright (c) 2012 RedHat
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/gnome-branding-MicroOS.spec
+++ b/testing/gnome-branding-MicroOS.spec
@@ -1,0 +1,86 @@
+#
+# spec file for package gnome-branding-MicroOS
+#
+# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2021 SUSE Software Solutions GmbH
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           gnome-branding-MicroOS
+Summary:        MicroOS Desktop default settings
+License:        BSD-3-Clause
+Group:          System/GUI/GNOME
+URL:            http://www.gtk.org/
+Source:         COPYING
+Source1:        MicroOS.gschema.override
+Source2:        flathub.flatpakrepo
+Source3:        mod-firstboot.desktop
+Source4:        mod-firstboot
+Source5:        50-desktop.conf
+BuildArch:      noarch
+BuildRequires:  flatpak
+BuildRequires:  gio-branding-openSUSE
+BuildRequires:  transactional-update
+Requires:       flatpak
+Requires:       gio-branding-openSUSE
+Requires:       sound-theme-freedesktop
+Requires:       transactional-update
+Requires:       zenity
+Conflicts:      plasma-branding-MicroOS
+Version:        20230420
+Release:        0
+
+%description
+This package provides MicroOS defaults for GNOME settings.
+
+%prep
+%setup -q -T -c %{name}-%{version}
+cp -a %{SOURCE0} COPYING
+cp -a %{SOURCE1} 30_MicroOS.gschema.override
+cp -a %{SOURCE2} flathub.flatpakrepo
+cp -a %{SOURCE3} mod-firstboot.desktop
+cp -a %{SOURCE4} mod-firstboot
+cp -a %{SOURCE5} 50-desktop.conf
+
+%build
+
+%install
+install -d %{buildroot}%{_datadir}/glib-2.0/schemas
+install -m0644 30_MicroOS.gschema.override %{buildroot}%{_datadir}/glib-2.0/schemas/
+install -d %{buildroot}%{_prefix}/share/microos-desktop
+install -m0644 flathub.flatpakrepo %{buildroot}%{_prefix}/share/microos-desktop
+install -d %{buildroot}%{_sysconfdir}/skel/.config/autostart
+install -m0644 mod-firstboot.desktop %{buildroot}%{_sysconfdir}/skel/.config/autostart/mod-firstboot.desktop
+install -d %{buildroot}%{_bindir}
+install -m0755 mod-firstboot %{buildroot}%{_bindir}/mod-firstboot
+install -d %{buildroot}%{_prefix}%{_sysconfdir}/transactional-update.conf.d
+install -m644 50-desktop.conf %{buildroot}%{_prefix}%{_sysconfdir}/transactional-update.conf.d/50-desktop.conf
+
+%post
+
+%postun
+
+%files
+%license COPYING
+%{_datadir}/glib-2.0/schemas/30_MicroOS.gschema.override
+%dir %{_prefix}/share/microos-desktop
+%{_prefix}/share/microos-desktop/flathub.flatpakrepo
+%dir %{_sysconfdir}/skel/.config
+%dir %{_sysconfdir}/skel/.config/autostart
+%config(noreplace) %{_sysconfdir}/skel/.config/autostart/mod-firstboot.desktop
+%{_bindir}/mod-firstboot
+%dir %{_prefix}%{_sysconfdir}/transactional-update.conf.d
+%{_prefix}%{_sysconfdir}/transactional-update.conf.d/50-desktop.conf
+
+%changelog

--- a/testing/gnome-branding-MicroOS.spec.out
+++ b/testing/gnome-branding-MicroOS.spec.out
@@ -1,8 +1,8 @@
 #
 # spec file for package gnome-branding-MicroOS
 #
-# Copyright (c) 2021 SUSE LLC
-# Copyright (c) 2021 SUSE Software Solutions GmbH
+# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2021 SUSE LLCSoftware Solutions GmbH
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/gnome-branding-MicroOS.spec.out
+++ b/testing/gnome-branding-MicroOS.spec.out
@@ -1,0 +1,86 @@
+#
+# spec file for package gnome-branding-MicroOS
+#
+# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2021 SUSE Software Solutions GmbH
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           gnome-branding-MicroOS
+Summary:        MicroOS Desktop default settings
+License:        BSD-3-Clause
+Group:          System/GUI/GNOME
+URL:            http://www.gtk.org/
+Source:         COPYING
+Source1:        MicroOS.gschema.override
+Source2:        flathub.flatpakrepo
+Source3:        mod-firstboot.desktop
+Source4:        mod-firstboot
+Source5:        50-desktop.conf
+BuildArch:      noarch
+BuildRequires:  flatpak
+BuildRequires:  gio-branding-openSUSE
+BuildRequires:  transactional-update
+Requires:       flatpak
+Requires:       gio-branding-openSUSE
+Requires:       sound-theme-freedesktop
+Requires:       transactional-update
+Requires:       zenity
+Conflicts:      plasma-branding-MicroOS
+Version:        20230420
+Release:        0
+
+%description
+This package provides MicroOS defaults for GNOME settings.
+
+%prep
+%setup -q -T -c %{name}-%{version}
+cp -a %{SOURCE0} COPYING
+cp -a %{SOURCE1} 30_MicroOS.gschema.override
+cp -a %{SOURCE2} flathub.flatpakrepo
+cp -a %{SOURCE3} mod-firstboot.desktop
+cp -a %{SOURCE4} mod-firstboot
+cp -a %{SOURCE5} 50-desktop.conf
+
+%build
+
+%install
+install -d %{buildroot}%{_datadir}/glib-2.0/schemas
+install -m0644 30_MicroOS.gschema.override %{buildroot}%{_datadir}/glib-2.0/schemas/
+install -d %{buildroot}%{_prefix}/share/microos-desktop
+install -m0644 flathub.flatpakrepo %{buildroot}%{_prefix}/share/microos-desktop
+install -d %{buildroot}%{_sysconfdir}/skel/.config/autostart
+install -m0644 mod-firstboot.desktop %{buildroot}%{_sysconfdir}/skel/.config/autostart/mod-firstboot.desktop
+install -d %{buildroot}%{_bindir}
+install -m0755 mod-firstboot %{buildroot}%{_bindir}/mod-firstboot
+install -d %{buildroot}%{_prefix}%{_sysconfdir}/transactional-update.conf.d
+install -m644 50-desktop.conf %{buildroot}%{_prefix}%{_sysconfdir}/transactional-update.conf.d/50-desktop.conf
+
+%post
+
+%postun
+
+%files
+%license COPYING
+%{_datadir}/glib-2.0/schemas/30_MicroOS.gschema.override
+%dir %{_prefix}/share/microos-desktop
+%{_prefix}/share/microos-desktop/flathub.flatpakrepo
+%dir %{_sysconfdir}/skel/.config
+%dir %{_sysconfdir}/skel/.config/autostart
+%config(noreplace) %{_sysconfdir}/skel/.config/autostart/mod-firstboot.desktop
+%{_bindir}/mod-firstboot
+%dir %{_prefix}%{_sysconfdir}/transactional-update.conf.d
+%{_prefix}%{_sysconfdir}/transactional-update.conf.d/50-desktop.conf
+
+%changelog

--- a/testing/gnome-branding-MicroOS.spec.out
+++ b/testing/gnome-branding-MicroOS.spec.out
@@ -2,7 +2,7 @@
 # spec file for package gnome-branding-MicroOS
 #
 # Copyright (c) 2023 SUSE LLC
-# Copyright (c) 2021 SUSE LLCSoftware Solutions GmbH
+# Copyright (c) 2021 SUSE Software Solutions GmbH
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/header.spec.out
+++ b/testing/header.spec.out
@@ -2,7 +2,8 @@
 #
 # spec file for package header
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2011 SUSE LLC
+# Copyright (c) 2019 SUSE LLC
 # Copyright (c) 2012 Dominique Leuenberger, Amsterdam, The Netherlands
 # Copyright #C 2013 Broken copyright
 #

--- a/testing/headercomment.spec.out
+++ b/testing/headercomment.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package headercomment
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2013 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/hugedefine.spec.out
+++ b/testing/hugedefine.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package hugedefine
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/interestingheader.spec.out
+++ b/testing/interestingheader.spec.out
@@ -1,7 +1,6 @@
 #
 # spec file for package interestingheader
 #
-# Copyright (c) 2021 SUSE LLC
 #  Copyright (c) 2011 Edgar Aichinger <edogawa@aon.at>
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/keep-condition-ordering.spec.out
+++ b/testing/keep-condition-ordering.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package keep-condition-ordering
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/kernel-firmware.spec.out
+++ b/testing/kernel-firmware.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package kernel-firmware
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/lafileextended.spec.out
+++ b/testing/lafileextended.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package lafileextended
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/lafilefix.spec.out
+++ b/testing/lafilefix.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package lafilefix
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/langpackage.spec.out
+++ b/testing/langpackage.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package langpackage
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/ldconfigscriptlets.spec.out
+++ b/testing/ldconfigscriptlets.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package ldconfigscriptlets
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/licenseand.spec.out
+++ b/testing/licenseand.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package licenseand
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/licenseoptions.spec.out
+++ b/testing/licenseoptions.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package licenseoptions
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/licenses.spec.out
+++ b/testing/licenses.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package licenses
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/licensesout.spec.out
+++ b/testing/licensesout.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package licensesout
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/macros.spec.out
+++ b/testing/macros.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package macros
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/makeflags.spec.out
+++ b/testing/makeflags.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package makeflags
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/makeinstall.spec.out
+++ b/testing/makeinstall.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package makeinstall
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/makeparams.spec.out
+++ b/testing/makeparams.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package makeparams
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/mandirs.spec.out
+++ b/testing/mandirs.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package mandirs
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/mingw32-clutter.spec.out
+++ b/testing/mingw32-clutter.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package mingw32-clutter
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2014 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/multilinecomment.spec.out
+++ b/testing/multilinecomment.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package multilinecomment
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/multilinedefine.spec.out
+++ b/testing/multilinedefine.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package multilinedefine
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/multilineexpand.spec.out
+++ b/testing/multilineexpand.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package multilineexpand
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/nestedcondition.spec.out
+++ b/testing/nestedcondition.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package nestedcondition
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/nospacebuildrequires.spec.out
+++ b/testing/nospacebuildrequires.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package nospacebuildrequires
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/onelinedeps.spec.out
+++ b/testing/onelinedeps.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package onelinedeps
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/packageand.spec.out
+++ b/testing/packageand.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package packageand
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/patches.spec.out
+++ b/testing/patches.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package patches
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/patterns.spec.out
+++ b/testing/patterns.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package patterns
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/perl-License.spec.out
+++ b/testing/perl-License.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package perl-License
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2016 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/perl-Text-Unidecode.spec.out
+++ b/testing/perl-Text-Unidecode.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package perl-Text-Unidecode
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2016 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/perl.spec.out
+++ b/testing/perl.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package perl
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/perldeps.spec.out
+++ b/testing/perldeps.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package perldeps
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pkgconf.spec.out
+++ b/testing/pkgconf.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pkgconf
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pkgconfigdeps.spec.out
+++ b/testing/pkgconfigdeps.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pkgconfigdeps
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pkgconfrequires.spec.out
+++ b/testing/pkgconfrequires.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pkgconfrequires
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pkgconfrequirescondition.spec.out
+++ b/testing/pkgconfrequirescondition.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pkgconfrequirescondition
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/ppcoldsupport.spec.out
+++ b/testing/ppcoldsupport.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package ppcoldsupport
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/prefix.spec.out
+++ b/testing/prefix.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package prefix
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/prereq.spec.out
+++ b/testing/prereq.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package prereq
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/providesobsoletes.spec.out
+++ b/testing/providesobsoletes.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package providesobsoletes
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pypi-url-modname.spec.out
+++ b/testing/pypi-url-modname.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pypi-url-modname
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pypi-url.spec.out
+++ b/testing/pypi-url.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pypi-url
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pytest.spec.out
+++ b/testing/pytest.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pytest
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/python-dephell_changelogs.spec.out
+++ b/testing/python-dephell_changelogs.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package python-dephell_changelogs
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/python-dephell_changelogs_02.spec.out
+++ b/testing/python-dephell_changelogs_02.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package python-dephell_changelogs_02
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/python-expand.spec.out
+++ b/testing/python-expand.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package python-expand
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/python-soupsieve.spec.out
+++ b/testing/python-soupsieve.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package python-soupsieve
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/python_subpackages.spec.out
+++ b/testing/python_subpackages.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package python_subpackages
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/pyunittest.spec.out
+++ b/testing/pyunittest.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package pyunittest
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/release.spec.out
+++ b/testing/release.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package release
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/removepath.spec.out
+++ b/testing/removepath.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package removepath
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/replace_pwdutils.spec.out
+++ b/testing/replace_pwdutils.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package replace_pwdutils
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/requires.spec.out
+++ b/testing/requires.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package requires
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/rpathreplacement.spec.out
+++ b/testing/rpathreplacement.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package rpathreplacement
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/rpmcallpkg.spec.out
+++ b/testing/rpmcallpkg.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package rpmcallpkg
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/rpmcmd.spec.out
+++ b/testing/rpmcmd.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package rpmcmd
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/rpmpreamble.spec.out
+++ b/testing/rpmpreamble.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package rpmpreamble
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2013 SUSE LLC
 # Copyright (c) 2010,2011,2012  Stephan Kleine
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/scriplets.spec.out
+++ b/testing/scriplets.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package scriplets
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/scriptletline.spec.out
+++ b/testing/scriptletline.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package scriptletline
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/sectiondefine.spec.out
+++ b/testing/sectiondefine.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package sectiondefine
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/skipped.changes
+++ b/testing/skipped.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Fri Feb  7 19:17:08 UTC 2025 - Bernhard Wiedemann <bwiedemann@suse.com>
+
+- dummy changelog to show that no second copyright line is added

--- a/testing/skipped.spec.out
+++ b/testing/skipped.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package skipped
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2017 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/slowparse.spec.out
+++ b/testing/slowparse.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package slowparse
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/sourcemacro.spec.out
+++ b/testing/sourcemacro.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package sourcemacro
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/sources.spec.out
+++ b/testing/sources.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package sources
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/sourcespatches.spec.out
+++ b/testing/sourcespatches.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package sourcespatches
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/spec-cleaner.spec.out
+++ b/testing/spec-cleaner.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package spec-cleaner
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2013 SUSE LLC
 # Copyright (c) 2012 Vincent Untz <vuntz@opensuse.org>
 #
 # All modifications and additions to the file contributed by third parties

--- a/testing/susekmp.spec.out
+++ b/testing/susekmp.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package susekmp
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/sysusers.spec.out
+++ b/testing/sysusers.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package sysusers
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/tex.spec.out
+++ b/testing/tex.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package tex
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/unbraceunder.spec.out
+++ b/testing/unbraceunder.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package unbraceunder
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/url_https.spec.out
+++ b/testing/url_https.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package url_https
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/version_regex.spec.out
+++ b/testing/version_regex.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package version_regex
 #
-# Copyright (c) 2021 SUSE LLC
+# Copyright (c) 2013 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/whitespace-build.spec.out
+++ b/testing/whitespace-build.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package whitespace-build
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/testing/whitespace.spec.out
+++ b/testing/whitespace.spec.out
@@ -1,7 +1,7 @@
 #
 # spec file for package whitespace
 #
-# Copyright (c) 2021 SUSE LLC
+
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
OBS spec file development involves non-SUSE people and we should not claim an automatic SUSE-Copyright for their work.

This includes all 3 commits from PR #72 - please review individual commits and comment the ones from the other PR there.