### PR TITLE
Don't add unneeded empty lines after Copyrights

### DIFF
--- a/prepare_spec
+++ b/prepare_spec
@@ -836,7 +836,7 @@ EOF
             # For non-SUSE copyrights assume that any subsequent
             # comment or empty line belongs to the copyright.
 
-            while ($readspec[0] =~ m/(^#.*)|(^\s*$)/ &&
+            while ($readspec[0] =~ m/(^#.*)/ &&
                    $readspec[0] !~ /^#(\![^\s]|\s*(Copyright|icecream|nodebuginfo|norootforbuild|usedforbuild|needsrootforbuild|needsbinariesforbuild|needssslcertforbuild|needspubkeyforbuild|usedforbuild)\s*)/) {
               $self->find("preamble")->add_copyright(shift @readspec);
             }


### PR DESCRIPTION
Conversion results were not idempotent before the Copyright patchset was merged in 3567c055567ed4e95d09dddf40a16aa2e7933f97. Commit f3da7b1aa8c59dbebaae2e8afdeeda4b0a206cae has introduced more issues. This commit retifies these.