### PR TITLE
A "+" suffix is only allowed for license-id

### DIFF
--- a/fetch-licenses.sh
+++ b/fetch-licenses.sh
@@ -7,7 +7,9 @@ curl -s -L 'https://docs.google.com/spreadsheets/d/14AdaJ6cmU0kvQ4ulq9pWpjdZL5tk
   | sed -e 's,\s*$,,' > licenses_changes.ntxt
 
 : > licenses_changes.ptxt
-grep -E "^(LicenseRef-SUSE-|SUSE-)" licenses_changes.ntxt | cut -d'	' -f1 | while read l; do
+# LicenseRef does not allow "+" as part of simple-expression, see
+# https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/#overview
+grep -E "^SUSE-" licenses_changes.ntxt | cut -d'	' -f1 | while read l; do
   echo "$l+	$l+" >> licenses_changes.ptxt ;
 done
 

--- a/licenses_changes.txt
+++ b/licenses_changes.txt
@@ -575,18 +575,12 @@ LiLiQ-Rplus-1.1	LiLiQ-Rplus-1.1
 Libpng	Libpng
 LicenseRef-SUSE-EULA	SUSE End User License Agreement
 LicenseRef-SUSE-EULA	SUSE-EULA
-LicenseRef-SUSE-EULA+	LicenseRef-SUSE-EULA+
 LicenseRef-SUSE-Freeware	SUSE-Freeware
-LicenseRef-SUSE-Freeware+	LicenseRef-SUSE-Freeware+
 LicenseRef-SUSE-GPL-2.0-with-openssl-exception	SUSE-GPL-2.0-with-openssl-exception
-LicenseRef-SUSE-GPL-2.0-with-openssl-exception+	LicenseRef-SUSE-GPL-2.0-with-openssl-exception+
 LicenseRef-SUSE-NonFree	SUSE-NonFree
-LicenseRef-SUSE-NonFree+	LicenseRef-SUSE-NonFree+
 LicenseRef-SUSE-Permissive	Must not be copyleft. Must not contain patent clauses of any nature. Most not limit ability to copy, modifiy, distribute (through multiple tiers of distribution) and distribute modified versions. Must not impose obligations such as 'advertising clauses' or anything that could be viewed as an 'additional restriction' under GPL-2.0+ or GPL-3.0+. Must not impose obligations such as modification by patch only, or reciprocal clauses.
 LicenseRef-SUSE-Permissive	SUSE-Permissive
-LicenseRef-SUSE-Permissive+	LicenseRef-SUSE-Permissive+
 LicenseRef-SUSE-Public-Domain	SUSE-Public-Domain
-LicenseRef-SUSE-Public-Domain+	LicenseRef-SUSE-Public-Domain+
 Linux-OpenIB	Linux-OpenIB
 Linux-man-pages-1-para	Linux-man-pages-1-para
 Linux-man-pages-copyleft	Linux-man-pages-copyleft


### PR DESCRIPTION
grammar is:

  simple-expression = license-id / license-id"+" / license-ref

where license-id is not licenseref:

license-id = <short form license identifier from SPDX License List> license-ref = [%s"DocumentRef-"(idstring)":"]%s"LicenseRef-"(idstring)